### PR TITLE
Introduce tag-based draft releases

### DIFF
--- a/.github/workflows/changelog_config.json
+++ b/.github/workflows/changelog_config.json
@@ -1,0 +1,6 @@
+{
+    "template": "## Changes since ${{FROM_TAG}}\n\n${{CHANGELOG}}\n\n${{UNCATEGORIZED}}",
+    "pr_template": "- #${{NUMBER}} ${{TITLE}}",
+    "empty_template": "## No changes since ${{FROM_TAG}}",
+    "sort": "DESC"
+}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,7 +1,9 @@
 name: "publish-release"
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 jobs:
   npm-publish:
@@ -47,10 +49,16 @@ jobs:
         run: |
           set -x
           PKG_NAME=marine
+          WS_LIST=$(cargo ws list -l)
           # substr(x, 2) removes first character from x. In case of version it's 'v' in 'v0.0.0'
-          VERSION=$(cargo ws list -l | grep "$PKG_NAME " | head -n1 | awk '{ print substr($2, 2) }')
+          VERSION=$(echo $WS_LIST | grep "$PKG_NAME " | head -n1 | awk '{ print substr($2, 2) }')
           echo "VERSION=$VERSION" | tee -a $GITHUB_ENV
           echo "PKG_NAME=$PKG_NAME" | tee -a $GITHUB_ENV
+          
+          # write WS_LIST to GITHUB_ENV. It's a multiline variable, that's why we need HEREDOC stuff (<<EOF)
+          echo "WS_LIST<<EOF" >> $GITHUB_ENV
+          echo "$WS_LIST" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Publish to crates.io
         run: cargo ws publish --no-git-commit --from-git --skip-published --yes
@@ -58,6 +66,34 @@ jobs:
       - name: Build release binaries of marine & mrepl
         run: cargo build --release -p marine -p mrepl
 
+      - name: Build Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v1
+        with:
+          configuration: ".github/workflows/changelog_config.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build packages link list
+        id: link_list
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            try {
+                let ws_list = `${{ env.WS_LIST }}`
+                console.log("ws_list: ", ws_list);
+                let lines = ws_list.split("\n");
+                let columns = lines.map(l => l.split(' ').filter(e => e.length > 0));
+                let link_list = columns.map(line => 
+                  `- [${line[0]} ${line[1]}](https://crates.io/crates/${line[0]}/${line[1]})`
+                ).join('\n');
+                return link_list;
+            } catch (e) {
+              console.log("Err: " + e);
+              throw e;
+            }
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -65,11 +101,14 @@ jobs:
           name: Marine WASM Runtime ${{ env.VERSION }}
           tag_name: ${{ env.VERSION }}
           body: |
-            - [${{ env.VERSION }} @ crates.io](https://crates.io/crates/${{ env.PKG_NAME }}/${{ env.VERSION }})
+            ${{steps.changelog.outputs.changelog}}
+
+            ## crates.io
+            ${{ steps.link_list.outputs.result }}
           files: |
             target/release/marine
             target/release/mrepl
-          draft: false
+          draft: true
           prerelease: false
           fail_on_unmatched_files: true
         env:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,24 @@
+name: "tag"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  tag:
+    name: "Tag"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get branch
+        run: |
+          BRANCH=${GITHUB_REF#refs/*/}
+          SANITIZED=$(echo "$BRANCH" | sed -e 's/[^a-zA-Z0-9-]/-/g')
+          echo "BRANCH=$SANITIZED" >> $GITHUB_ENV
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v5.5
+        with:
+          append_to_pre_release_tag: ${{ env.BRANCH }}
+          github_token: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
The release scheme is as follows.

## Tags
A release is created on a tag push. The tag must be prefixed with `v`, e.g., `v0.2.3`.

Tags can be pushed either manually or via `tag.yml` GitHub Action via a press of the button. 

Tags can be moved if needed, like this:
```
# Remove tag
git push -d origin v0.2.3 && git tag -d v0.2.3 
# Mark current commit with a tag and push
git tag v0.2.3 && git push origin v0.2.3
```
In such a case, the release action will be executed against the new commit and the existing `v0.2.3` release will be moved to Draft status. One would rarely need such a trick, but it's useful to know of it.

## Changelog
On each release, a changelog is generated. The changelog is calculated from Pull Requests merged between a previous semver-looking tag and a newly pushed one. So, given that there was a release `v0.2.2`, on a push of `v0.2.3` changelog will be generated from PRs that were merged since `v0.2.2` until the commit marked with `v0.2.3`.

Changelog format can be easily changed in the `changelog_config.json` file. It is also possible to set up PR grouping by labels or by regex.

## Release
GitHub release is created in status 'Draft' to avoid notifying repository watchers. Repository maintainers must review the release and make it public manually.

## Publishing
On each release, all publishable crates are published to crates.io. Their versions are published as is, i.e. exactly as specified in Cargo.toml's. Because of that, it is possible that the same versions of crates exist in different releases. It gives maintainers the finest control over publishing.