### PR TITLE
Add call_with_ivalues method to FluenceAppService

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 
 [[package]]
 name = "fluence-app-service"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "fluence-faas 0.9.1",
  "log",
@@ -1871,7 +1871,7 @@ dependencies = [
  "check-latest",
  "clap",
  "env_logger 0.7.1",
- "fluence-app-service 0.9.1",
+ "fluence-app-service 0.10.0",
  "itertools 0.9.0",
  "log",
  "marine-rs-sdk-main",
@@ -2752,9 +2752,9 @@ checksum = "c307a32c1c5c437f38c7fd45d753050587732ba8628319fbdf12a7e289ccc590"
 
 [[package]]
 name = "smallvec"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"

--- a/fluence-app-service/Cargo.toml
+++ b/fluence-app-service/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fluence-app-service"
 description = "Fluence Application Service"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"

--- a/fluence-app-service/src/service.rs
+++ b/fluence-app-service/src/service.rs
@@ -20,6 +20,7 @@ use crate::service_interface::ServiceInterface;
 use super::AppServiceError;
 
 use fluence_faas::FluenceFaaS;
+use fluence_faas::IValue;
 use serde_json::Value as JValue;
 
 use std::convert::TryInto;
@@ -69,7 +70,7 @@ impl AppService {
         })
     }
 
-    /// Call a specified function of loaded module by its name.
+    /// Call a specified function of loaded module by its name with arguments in json format.
     // TODO: replace serde_json::Value with Vec<u8>?
     pub fn call<S: AsRef<str>>(
         &mut self,
@@ -79,6 +80,23 @@ impl AppService {
     ) -> Result<JValue> {
         self.faas
             .call_with_json(
+                &self.facade_module_name,
+                func_name,
+                arguments,
+                call_parameters,
+            )
+            .map_err(Into::into)
+    }
+
+    /// Call a specified function of loaded module by its name with arguments in .
+    pub fn call_with_ivalues<S: AsRef<str>>(
+        &mut self,
+        func_name: S,
+        arguments: &[IValue],
+        call_parameters: crate::CallParameters,
+    ) -> Result<Vec<IValue>> {
+        self.faas
+            .call_with_ivalues(
                 &self.facade_module_name,
                 func_name,
                 arguments,

--- a/fluence-app-service/src/service.rs
+++ b/fluence-app-service/src/service.rs
@@ -88,7 +88,7 @@ impl AppService {
             .map_err(Into::into)
     }
 
-    /// Call a specified function of loaded module by its name with arguments in .
+    /// Call a specified function of loaded module by its name with arguments in IValue format.
     pub fn call_with_ivalues<S: AsRef<str>>(
         &mut self,
         func_name: S,

--- a/tools/repl/Cargo.toml
+++ b/tools/repl/Cargo.toml
@@ -12,7 +12,7 @@ name = "mrepl"
 path = "src/main.rs"
 
 [dependencies]
-fluence-app-service = { path = "../../fluence-app-service", version = "0.9.0", features = ["raw-module-api"] }
+fluence-app-service = { path = "../../fluence-app-service", version = "0.10.0", features = ["raw-module-api"] }
 marine-rs-sdk-main = { version = "0.6.10", features = ["logger"] }
 
 anyhow = "1.0.31"


### PR DESCRIPTION
We've decided to use only `IValue` instead of mix of `JValue` with `IValue` everywhere inside node, because it would be more transparent for the interpreter and other part of node.