### PR TITLE
bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "fluence-app-service"
-version = "0.14.1"
+version = "0.15.0"
 dependencies = [
- "fluence-faas 0.13.1",
+ "fluence-faas 0.14.0",
  "log",
  "maplit",
  "marine-min-it-version",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "fluence-faas"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "bytesize",
  "cmd_lib",
@@ -836,10 +836,10 @@ dependencies = [
  "it-json-serde",
  "itertools 0.9.0",
  "log",
- "marine-module-interface 0.2.0",
+ "marine-module-interface 0.3.0",
  "marine-rs-sdk",
  "marine-rs-sdk-main",
- "marine-runtime 0.11.0",
+ "marine-runtime 0.12.0",
  "marine-utils 0.4.0",
  "once_cell",
  "pretty_assertions",
@@ -862,19 +862,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "047f670b4807cab8872550a607b1515daff08b3e3bb7576ce8f45971fd811a4e"
 dependencies = [
- "it-to-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "nom",
- "serde",
- "variant_count",
- "wast",
-]
-
-[[package]]
-name = "fluence-it-types"
-version = "0.3.1"
-source = "git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory#72b053b8730066c0f5d3d967d7a314919236c199"
-dependencies = [
- "it-to-bytes 0.1.0 (git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory)",
+ "it-to-bytes",
  "nom",
  "serde",
  "variant_count",
@@ -1351,7 +1339,7 @@ checksum = "35e70ee094dc02fd9c13fdad4940090f22dbd6ac7c9e7094a46cf0232a50bc7c"
 
 [[package]]
 name = "it-json-serde"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1367,7 +1355,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99ccf40e1e08f6f47ffbafe3cfb2e3adb721ddde80b178240f038d07dc9652fb"
 dependencies = [
- "fluence-it-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluence-it-types",
  "log",
  "paste",
  "thiserror",
@@ -1376,9 +1364,10 @@ dependencies = [
 [[package]]
 name = "it-lilo"
 version = "0.3.0"
-source = "git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory#72b053b8730066c0f5d3d967d7a314919236c199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea8088acc275f9f8112632075730e10ebbf143d526017e4faa0bb6a215fa3c2b"
 dependencies = [
- "fluence-it-types 0.3.1 (git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory)",
+ "fluence-it-types",
  "it-memory-traits",
  "log",
  "paste",
@@ -1388,7 +1377,8 @@ dependencies = [
 [[package]]
 name = "it-memory-traits"
 version = "0.2.0"
-source = "git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory#72b053b8730066c0f5d3d967d7a314919236c199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8587a124e05788087174863e613903a0987d3baceda89d154549e5bb914e2543"
 dependencies = [
  "thiserror",
 ]
@@ -1398,11 +1388,6 @@ name = "it-to-bytes"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "729c74bb4236418898a219c6d96f14cba77456dd7c04a2e99e65e9c643709b56"
-
-[[package]]
-name = "it-to-bytes"
-version = "0.1.0"
-source = "git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory#72b053b8730066c0f5d3d967d7a314919236c199"
 
 [[package]]
 name = "itertools"
@@ -1519,7 +1504,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "marine"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -1527,8 +1512,8 @@ dependencies = [
  "check-latest",
  "clap",
  "exitfailure",
- "marine-it-generator 0.6.0",
- "marine-it-parser 0.7.0",
+ "marine-it-generator 0.7.0",
+ "marine-it-parser 0.8.0",
  "marine-module-info-parser 0.2.2",
  "semver 0.11.0",
  "serde",
@@ -1567,11 +1552,11 @@ dependencies = [
 
 [[package]]
 name = "marine-it-generator"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "cargo_toml",
  "it-lilo 0.3.0",
- "marine-it-parser 0.7.0",
+ "marine-it-parser 0.8.0",
  "marine-macro-impl",
  "once_cell",
  "serde",
@@ -1593,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "marine-it-interfaces"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "multimap",
  "wasmer-interface-types-fl 0.22.0",
@@ -1620,12 +1605,12 @@ dependencies = [
 
 [[package]]
 name = "marine-it-parser"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "itertools 0.10.3",
- "marine-it-interfaces 0.5.0",
- "marine-module-interface 0.2.0",
+ "marine-it-interfaces 0.6.0",
+ "marine-module-interface 0.3.0",
  "nom",
  "semver 0.11.0",
  "serde",
@@ -1717,11 +1702,11 @@ dependencies = [
 
 [[package]]
 name = "marine-module-interface"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "itertools 0.10.3",
- "marine-it-interfaces 0.5.0",
+ "marine-it-interfaces 0.6.0",
  "nom",
  "semver 0.11.0",
  "serde",
@@ -1799,7 +1784,7 @@ dependencies = [
 
 [[package]]
 name = "marine-runtime"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -1808,12 +1793,12 @@ dependencies = [
  "it-lilo 0.3.0",
  "it-memory-traits",
  "log",
- "marine-it-generator 0.6.0",
- "marine-it-interfaces 0.5.0",
- "marine-it-parser 0.7.0",
+ "marine-it-generator 0.7.0",
+ "marine-it-interfaces 0.6.0",
+ "marine-it-parser 0.8.0",
  "marine-min-it-version",
  "marine-module-info-parser 0.2.2",
- "marine-module-interface 0.2.0",
+ "marine-module-interface 0.3.0",
  "marine-utils 0.4.0",
  "multimap",
  "once_cell",
@@ -1893,22 +1878,22 @@ version = "0.4.0"
 
 [[package]]
 name = "marine-web-runtime"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "boolinator",
  "bytesize",
  "console_error_panic_hook",
- "fluence-it-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluence-it-types",
  "it-json-serde",
  "it-lilo 0.3.0",
  "it-memory-traits",
  "itertools 0.10.3",
  "log",
  "maplit",
- "marine-it-interfaces 0.5.0",
+ "marine-it-interfaces 0.6.0",
  "marine-min-it-version",
- "marine-module-interface 0.2.0",
+ "marine-module-interface 0.3.0",
  "marine-rs-sdk",
  "marine-utils 0.4.0",
  "multimap",
@@ -2040,13 +2025,13 @@ dependencies = [
 
 [[package]]
 name = "mrepl"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "check-latest",
  "clap",
  "env_logger 0.7.1",
- "fluence-app-service 0.14.1",
+ "fluence-app-service 0.15.0",
  "itertools 0.9.0",
  "log",
  "marine-rs-sdk-main",
@@ -3698,9 +3683,9 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14ba3b5a07989987994b96bf5cc7ac2947005f9ff6123d71b7064232f07d28fa"
 dependencies = [
- "fluence-it-types 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fluence-it-types",
  "it-lilo 0.1.0",
- "it-to-bytes 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "it-to-bytes",
  "itertools 0.10.3",
  "log",
  "nom",
@@ -3715,12 +3700,13 @@ dependencies = [
 [[package]]
 name = "wasmer-interface-types-fl"
 version = "0.22.0"
-source = "git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory#72b053b8730066c0f5d3d967d7a314919236c199"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1571d6f8f11e181dabddbc01017dd928007c08f567fb2ba4611583d259513ca6"
 dependencies = [
- "fluence-it-types 0.3.1 (git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory)",
+ "fluence-it-types",
  "it-lilo 0.3.0",
  "it-memory-traits",
- "it-to-bytes 0.1.0 (git+https://github.com/fluencelabs/interface-types?branch=use_u32_for_memory)",
+ "it-to-bytes",
  "itertools 0.10.3",
  "log",
  "nom",

--- a/crates/it-generator/Cargo.toml
+++ b/crates/it-generator/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-it-generator"
 description = "Fluence Marine interface types generator"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"
@@ -11,7 +11,7 @@ name = "marine_it_generator"
 path = "src/lib.rs"
 
 [dependencies]
-marine-it-parser = { path = "../it-parser", version = "0.7.0"}
+marine-it-parser = { path = "../it-parser", version = "0.8.0"}
 marine-macro-impl = "0.6.10"
 
 wasmer-it = { package = "wasmer-interface-types-fl", version = "0.22.0" }

--- a/crates/it-interfaces/Cargo.toml
+++ b/crates/it-interfaces/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-it-interfaces"
 description = "Fluence Marine interface types helper crate"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"

--- a/crates/it-json-serde/Cargo.toml
+++ b/crates/it-json-serde/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "it-json-serde"
 description = "Fluence Marine interface-types serde tools"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"

--- a/crates/it-parser/Cargo.toml
+++ b/crates/it-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-it-parser"
 description = "Fluence Marine interface types parser"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"
@@ -11,8 +11,8 @@ name = "marine_it_parser"
 path = "src/lib.rs"
 
 [dependencies]
-marine-it-interfaces = { path = "../it-interfaces", version = "0.5.0" }
-marine-module-interface = { path = "../module-interface", version = "0.2.0" }
+marine-it-interfaces = { path = "../it-interfaces", version = "0.6.0" }
+marine-module-interface = { path = "../module-interface", version = "0.3.0" }
 
 anyhow = "1.0.31"
 walrus = "0.18.0"

--- a/crates/module-interface/Cargo.toml
+++ b/crates/module-interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-module-interface"
 description = "Fluence Marine module interface"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"
@@ -11,7 +11,7 @@ name = "marine_module_interface"
 path = "src/lib.rs"
 
 [dependencies]
-marine-it-interfaces = { path = "../it-interfaces", version = "0.5.0" }
+marine-it-interfaces = { path = "../it-interfaces", version = "0.6.0" }
 
 anyhow = "1.0.31"
 walrus = "0.18.0"

--- a/fluence-app-service/Cargo.toml
+++ b/fluence-app-service/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fluence-app-service"
 description = "Fluence Application Service"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-fluence-faas = { path = "../fluence-faas", version = "0.13.1" }
+fluence-faas = { path = "../fluence-faas", version = "0.14.0" }
 marine-min-it-version = { path = "../crates/min-it-version", version = "0.1.0" }
 
 maplit = "1.0.2"

--- a/fluence-faas/Cargo.toml
+++ b/fluence-faas/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "fluence-faas"
 description = "Fluence FaaS"
-version = "0.13.1"
+version = "0.14.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-marine-runtime = { path = "../runtime", version = "0.11.0" }
-marine-module-interface = { path = "../crates/module-interface", version = "0.2.0" }
+marine-runtime = { path = "../runtime", version = "0.12.0" }
+marine-module-interface = { path = "../crates/module-interface", version = "0.3.0" }
 marine-utils = { path = "../crates/utils", version = "0.4.0" }
 marine-rs-sdk-main = { version = "0.6.15", features = ["logger"] }
 marine-rs-sdk = { version = "0.6.15", features = ["logger"] }
-it-json-serde = { path = "../crates/it-json-serde", version = "0.1.0" }
+it-json-serde = { path = "../crates/it-json-serde", version = "0.2.0" }
 
 wasmer-runtime = { package = "wasmer-runtime-fl", version = "=0.17.1" }
 # dynamicfunc-fat-closures allows using state inside DynamicFunc

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-runtime"
 description = "Marine is the Fluence Compute Runtime"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"
@@ -12,10 +12,10 @@ path = "src/lib.rs"
 
 [dependencies]
 marine-module-info-parser = { path = "../crates/module-info-parser", version = "0.2.2" }
-marine-it-interfaces = { path = "../crates/it-interfaces", version = "0.5.0" }
-marine-it-parser = { path = "../crates/it-parser", version = "0.7.0" }
-marine-it-generator = { path = "../crates/it-generator", version = "0.6.0" }
-marine-module-interface = { path = "../crates/module-interface", version = "0.2.0" }
+marine-it-interfaces = { path = "../crates/it-interfaces", version = "0.6.0" }
+marine-it-parser = { path = "../crates/it-parser", version = "0.8.0" }
+marine-it-generator = { path = "../crates/it-generator", version = "0.7.0" }
+marine-module-interface = { path = "../crates/module-interface", version = "0.3.0" }
 marine-utils = { path = "../crates/utils", version = "0.4.0" }
 marine-min-it-version =  { path = "../crates/min-it-version", version = "0.1.0"}
 

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine"
 description = "Fluence Marine command line tool"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Fluence Labs"]
 repository = "https://github.com/fluencelabs/marine/tools/cli"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ name = "marine"
 path = "src/main.rs"
 
 [dependencies]
-marine-it-generator = { path = "../../crates/it-generator", version = "0.6.0" }
-marine-it-parser = { path = "../../crates/it-parser", version = "0.7.0" }
+marine-it-generator = { path = "../../crates/it-generator", version = "0.7.0" }
+marine-it-parser = { path = "../../crates/it-parser", version = "0.8.0" }
 marine-module-info-parser = { path = "../../crates/module-info-parser", version = "0.2.2" }
 
 semver = "0.11.0"

--- a/tools/repl/Cargo.toml
+++ b/tools/repl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mrepl"
 description = "Fluence Marine REPL intended for testing purposes"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Fluence Labs"]
 repository = "https://github.com/fluencelabs/marine/tools/repl"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ name = "mrepl"
 path = "src/main.rs"
 
 [dependencies]
-fluence-app-service = { path = "../../fluence-app-service", version = "0.14.0", features = ["raw-module-api"] }
+fluence-app-service = { path = "../../fluence-app-service", version = "0.15.0", features = ["raw-module-api"] }
 marine-rs-sdk-main = { version = "0.6.15", features = ["logger"] }
 
 anyhow = "1.0.31"

--- a/web-runtime/Cargo.toml
+++ b/web-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "marine-web-runtime"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 description = "Web version of marine-runtime"
 publish = false
@@ -10,8 +10,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-marine-it-interfaces = { path = "../crates/it-interfaces", version = "0.5.0" }
-marine-module-interface = { path = "../crates/module-interface", version = "0.2.0" }
+marine-it-interfaces = { path = "../crates/it-interfaces", version = "0.6.0" }
+marine-module-interface = { path = "../crates/module-interface", version = "0.3.0" }
 marine-utils = { path = "../crates/utils", version = "0.4.0" }
 marine-min-it-version =  { path = "../crates/min-it-version", version = "0.1.0"}
 
@@ -20,7 +20,7 @@ wasmer-it = { package = "wasmer-interface-types-fl", version = "0.22.0" }
 fluence-it-types = {version = "0.3.1", features = ["impls"] }
 it-lilo = "0.3.0"
 it-memory-traits = "0.2.0"
-it-json-serde = { path = "../crates/it-json-serde", version = "0.1.0" }
+it-json-serde = { path = "../crates/it-json-serde", version = "0.2.0" }
 
 wasm-bindgen = "0.2"
 nom = "5.1"

--- a/web-runtime/Cargo.toml
+++ b/web-runtime/Cargo.toml
@@ -14,13 +14,13 @@ marine-it-interfaces = { path = "../crates/it-interfaces", version = "0.6.0" }
 marine-module-interface = { path = "../crates/module-interface", version = "0.3.0" }
 marine-utils = { path = "../crates/utils", version = "0.4.0" }
 marine-min-it-version =  { path = "../crates/min-it-version", version = "0.1.0"}
+it-json-serde = { path = "../crates/it-json-serde", version = "0.2.0" }
 
 marine-rs-sdk = "0.6.15"
 wasmer-it = { package = "wasmer-interface-types-fl", version = "0.22.0" }
 fluence-it-types = {version = "0.3.1", features = ["impls"] }
 it-lilo = "0.3.0"
 it-memory-traits = "0.2.0"
-it-json-serde = { path = "../crates/it-json-serde", version = "0.2.0" }
 
 wasm-bindgen = "0.2"
 nom = "5.1"

--- a/web-runtime/npm-package/src/marine_web_runtime.js
+++ b/web-runtime/npm-package/src/marine_web_runtime.js
@@ -230,10 +230,6 @@ export async function init(module) {
     async function init(wasmModule) {
         const imports = {};
         imports.wbg = {};
-        imports.wbg.__wbg_getmemorysize_385fa0bd4e2d9ff6 = function(arg0) {
-            var ret = get_memory_size(getObject(arg0));
-            return ret;
-        };
         imports.wbg.__wbg_new_693216e109162396 = function() {
             var ret = new Error();
             return addHeapObject(ret);
@@ -255,23 +251,26 @@ export async function init(module) {
         imports.wbg.__wbindgen_object_drop_ref = function(arg0) {
             takeObject(arg0);
         };
-        imports.wbg.__wbg_writebyte_81064940ca9059c1 = function(arg0, arg1, arg2) {
+        imports.wbg.__wbg_writebyte_5cf11e3bc7462ec2 = function(arg0, arg1, arg2) {
             write_byte(getObject(arg0), arg1 >>> 0, arg2);
         };
-        imports.wbg.__wbg_writebyterange_313d990e0a3436b6 = function(arg0, arg1, arg2, arg3) {
-            write_byte_range(getObject(arg0), arg1 >>> 0, getArrayU8FromWasm0(arg2, arg3));
-        };
-        imports.wbg.__wbg_readbyterange_ebea9d02dea05828 = function(arg0, arg1, arg2, arg3) {
+        imports.wbg.__wbg_readbyterange_a6e4127576d4a165 = function(arg0, arg1, arg2, arg3) {
             read_byte_range(getObject(arg0), arg1 >>> 0, getArrayU8FromWasm0(arg2, arg3));
         };
-        imports.wbg.__wbg_callexport_cb1a6ee1197892bd = function(arg0, arg1, arg2, arg3, arg4, arg5) {
+        imports.wbg.__wbg_callexport_a4e71f5003bf3d97 = function(arg0, arg1, arg2, arg3, arg4, arg5) {
             var ret = call_export(getObject(arg1), getStringFromWasm0(arg2, arg3), getStringFromWasm0(arg4, arg5));
             var ptr0 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
             var len0 = WASM_VECTOR_LEN;
             getInt32Memory0()[arg0 / 4 + 1] = len0;
             getInt32Memory0()[arg0 / 4 + 0] = ptr0;
         };
-
+        imports.wbg.__wbg_getmemorysize_44ed7b542fa6e518 = function(arg0) {
+            var ret = get_memory_size(getObject(arg0));
+            return ret;
+        };
+        imports.wbg.__wbg_writebyterange_bca7718185fe74fe = function(arg0, arg1, arg2, arg3) {
+            write_byte_range(getObject(arg0), arg1 >>> 0, getArrayU8FromWasm0(arg2, arg3));
+        };
         const instance = await WebAssembly.instantiate(wasmModule, imports);
         wasm = instance.exports;
 


### PR DESCRIPTION
`wasmer-interface-types-fl` dependency minor version updated, so we update it everywhere it was used and bump minor versions everywhere transitively