### PR TITLE
Fix `marine build` output

### DIFF
--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine"
 description = "Fluence Marine command line tool"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Fluence Labs"]
 repository = "https://github.com/fluencelabs/marine/tools/cli"
 license = "Apache-2.0"

--- a/tools/cli/src/build.rs
+++ b/tools/cli/src/build.rs
@@ -38,7 +38,10 @@ pub(crate) fn build(trailing_args: Vec<&str>) -> CLIResult<()> {
     cargo.arg("--message-format").arg("json-render-diagnostics");
     cargo.args(trailing_args);
 
-    let output = crate::utils::run_command_inherited(cargo)
+    // piped here is used because cargo build prints all necessary for user compilation progress
+    // into stderr, while stdout is used for deep compiler-specific messages
+    // that DiagnosticMessage represents
+    let output = crate::utils::run_command_piped(cargo)
         .map_err(|e| CLIError::WasmCompilationError(e.to_string()))?;
     let mut wasms: Vec<String> = Vec::new();
     for line in output.lines() {

--- a/tools/cli/src/build.rs
+++ b/tools/cli/src/build.rs
@@ -38,8 +38,8 @@ pub(crate) fn build(trailing_args: Vec<&str>) -> CLIResult<()> {
     cargo.arg("--message-format").arg("json-render-diagnostics");
     cargo.args(trailing_args);
 
-    // piped here is used because cargo build prints all necessary for user compilation progress
-    // into stderr, while stdout is used for deep compiler-specific messages
+    // the piped mode is used here because cargo build prints all necessary for user
+    // compilation progress into stderr, while stdout is used for deep compiler-specific messages
     // that DiagnosticMessage represents
     let output = crate::utils::run_command_piped(cargo)
         .map_err(|e| CLIError::WasmCompilationError(e.to_string()))?;


### PR DESCRIPTION
Use piped mode for `stdout` in the `marine build` subcommand to prevent users to see internal messages.