### PR TITLE
Use `impl AsRef` instead generics params in Marine interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "fluence-app-service"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
- "fluence-faas 0.16.2",
+ "fluence-faas 0.16.3",
  "log",
  "maplit",
  "marine-min-it-version",
@@ -835,7 +835,7 @@ dependencies = [
 
 [[package]]
 name = "fluence-faas"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "bytesize",
  "cmd_lib",
@@ -846,7 +846,7 @@ dependencies = [
  "marine-module-interface 0.4.1",
  "marine-rs-sdk",
  "marine-rs-sdk-main",
- "marine-runtime 0.14.2",
+ "marine-runtime 0.14.3",
  "marine-utils 0.4.0",
  "once_cell",
  "pretty_assertions",
@@ -1093,7 +1093,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio 1.18.2",
- "tokio-util 0.7.1",
+ "tokio-util 0.7.2",
  "tracing",
 ]
 
@@ -1135,7 +1135,7 @@ checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes 1.1.0",
  "fnv",
- "itoa 1.0.1",
+ "itoa 1.0.2",
 ]
 
 [[package]]
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes 1.1.0",
  "http",
@@ -1222,10 +1222,10 @@ dependencies = [
  "futures-util",
  "h2 0.3.13",
  "http",
- "http-body 0.4.4",
+ "http-body 0.4.5",
  "httparse",
  "httpdate 1.0.2",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "pin-project-lite 0.2.9",
  "socket2 0.4.4",
  "tokio 1.18.2",
@@ -1422,9 +1422,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "js-sys"
@@ -1472,9 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "lilo-after-2gb-test"
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "marine-runtime"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "boolinator",
@@ -2034,7 +2034,7 @@ dependencies = [
  "check-latest",
  "clap",
  "env_logger 0.7.1",
- "fluence-app-service 0.17.2",
+ "fluence-app-service 0.17.3",
  "itertools 0.9.0",
  "log",
  "marine-rs-sdk-main",
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "openssl"
@@ -2405,11 +2405,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2469,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -2481,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2574,9 +2574,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -2635,7 +2635,7 @@ dependencies = [
  "futures-util",
  "h2 0.3.13",
  "http",
- "http-body 0.4.4",
+ "http-body 0.4.5",
  "hyper 0.14.18",
  "hyper-tls 0.5.0",
  "ipnet",
@@ -2729,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "safe-transmute"
@@ -2741,12 +2741,12 @@ checksum = "98a01dab6acf992653be49205bdd549f32f17cb2803e8eacf1560bf97259aae8"
 
 [[package]]
 name = "schannel"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2865,7 +2865,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -2877,7 +2877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -3008,13 +3008,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04066589568b72ec65f42d65a1a52436e954b168773148893c020269563decf2"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -3243,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0edfdeb067411dba2044da6d1cb2df793dd35add7888d73c16e3381ded401764"
+checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
 dependencies = [
  "bytes 1.1.0",
  "futures-core",
@@ -3383,6 +3383,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "unicode-normalization"

--- a/crates/it-generator/src/instructions_generator.rs
+++ b/crates/it-generator/src/instructions_generator.rs
@@ -29,7 +29,7 @@ use wasmer_it::IRecordType;
 
 use std::rc::Rc;
 
-#[derive(PartialEq, Debug, Default)]
+#[derive(PartialEq, Eq, Debug, Default)]
 pub(crate) struct ITResolver<'a> {
     types: std::collections::HashMap<String, usize>,
     pub(crate) interfaces: Interfaces<'a>,

--- a/fluence-app-service/Cargo.toml
+++ b/fluence-app-service/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fluence-app-service"
 description = "Fluence Application Service"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-fluence-faas = { path = "../fluence-faas", version = "0.16.2" }
+fluence-faas = { path = "../fluence-faas", version = "0.16.3" }
 marine-min-it-version = { path = "../crates/min-it-version", version = "0.1.0" }
 
 maplit = "1.0.2"

--- a/fluence-app-service/src/service.rs
+++ b/fluence-app-service/src/service.rs
@@ -41,10 +41,10 @@ pub struct AppService {
 
 impl AppService {
     /// Create Service with given modules and service id.
-    pub fn new<C, S>(config: C, service_id: S, envs: HashMap<Vec<u8>, Vec<u8>>) -> Result<Self>
+    pub fn new<S, C>(config: C, service_id: S, envs: HashMap<Vec<u8>, Vec<u8>>) -> Result<Self>
     where
-        C: TryInto<AppServiceConfig>,
         S: Into<String>,
+        C: TryInto<AppServiceConfig>,
         AppServiceError: From<C::Error>,
     {
         let mut config: AppServiceConfig = config.try_into()?;
@@ -73,9 +73,9 @@ impl AppService {
 
     /// Call a specified function of loaded module by its name with arguments in json format.
     // TODO: replace serde_json::Value with Vec<u8>?
-    pub fn call<S: AsRef<str>>(
+    pub fn call(
         &mut self,
-        func_name: S,
+        func_name: impl AsRef<str>,
         arguments: JValue,
         call_parameters: crate::CallParameters,
     ) -> Result<JValue> {
@@ -90,9 +90,9 @@ impl AppService {
     }
 
     /// Call a specified function of loaded module by its name with arguments in IValue format.
-    pub fn call_with_ivalues<S: AsRef<str>>(
+    pub fn call_with_ivalues(
         &mut self,
-        func_name: S,
+        func_name: impl AsRef<str>,
         arguments: &[IValue],
         call_parameters: crate::CallParameters,
     ) -> Result<Vec<IValue>> {
@@ -189,14 +189,14 @@ impl AppService {
 // This API is intended for testing purposes (mostly in Marine REPL)
 #[cfg(feature = "raw-module-api")]
 impl AppService {
-    pub fn new_with_empty_facade<C, S>(
+    pub fn new_with_empty_facade<S, C>(
         config: C,
         service_id: S,
         envs: HashMap<Vec<u8>, Vec<u8>>,
     ) -> Result<Self>
     where
-        C: TryInto<AppServiceConfig>,
         S: Into<String>,
+        C: TryInto<AppServiceConfig>,
         AppServiceError: From<C::Error>,
     {
         let mut config: AppServiceConfig = config.try_into()?;
@@ -211,10 +211,10 @@ impl AppService {
         })
     }
 
-    pub fn call_module<MN: AsRef<str>, FN: AsRef<str>>(
+    pub fn call_module(
         &mut self,
-        module_name: MN,
-        func_name: FN,
+        module_name: impl AsRef<str>,
+        func_name: impl AsRef<str>,
         arguments: JValue,
         call_parameters: crate::CallParameters,
     ) -> Result<JValue> {
@@ -234,7 +234,7 @@ impl AppService {
             .map_err(Into::into)
     }
 
-    pub fn unload_module<S: AsRef<str>>(&mut self, module_name: S) -> Result<()> {
+    pub fn unload_module(&mut self, module_name: impl AsRef<str>) -> Result<()> {
         self.faas.unload_module(module_name).map_err(Into::into)
     }
 
@@ -244,9 +244,9 @@ impl AppService {
     }
 
     /// Return
-    pub fn get_wasi_state<S: AsRef<str>>(
+    pub fn get_wasi_state(
         &mut self,
-        module_name: S,
+        module_name: impl AsRef<str>,
     ) -> Result<&wasmer_wasi::state::WasiState> {
         self.faas.module_wasi_state(module_name).map_err(Into::into)
     }

--- a/fluence-app-service/src/service.rs
+++ b/fluence-app-service/src/service.rs
@@ -41,7 +41,7 @@ pub struct AppService {
 
 impl AppService {
     /// Create Service with given modules and service id.
-    pub fn new<S, C>(config: C, service_id: S, envs: HashMap<Vec<u8>, Vec<u8>>) -> Result<Self>
+    pub fn new<C, S>(config: C, service_id: S, envs: HashMap<Vec<u8>, Vec<u8>>) -> Result<Self>
     where
         S: Into<String>,
         C: TryInto<AppServiceConfig>,
@@ -189,7 +189,7 @@ impl AppService {
 // This API is intended for testing purposes (mostly in Marine REPL)
 #[cfg(feature = "raw-module-api")]
 impl AppService {
-    pub fn new_with_empty_facade<S, C>(
+    pub fn new_with_empty_facade<C, S>(
         config: C,
         service_id: S,
         envs: HashMap<Vec<u8>, Vec<u8>>,
@@ -223,7 +223,7 @@ impl AppService {
             .map_err(Into::into)
     }
 
-    pub fn load_module<S, C>(&mut self, name: S, wasm_bytes: &[u8], config: Option<C>) -> Result<()>
+    pub fn load_module<C, S>(&mut self, name: S, wasm_bytes: &[u8], config: Option<C>) -> Result<()>
     where
         S: Into<String>,
         C: TryInto<crate::FaaSModuleConfig>,

--- a/fluence-faas/Cargo.toml
+++ b/fluence-faas/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fluence-faas"
 description = "Fluence FaaS"
-version = "0.16.2"
+version = "0.16.3"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
-marine-runtime = { path = "../runtime", version = "0.14.2" }
+marine-runtime = { path = "../runtime", version = "0.14.3" }
 marine-module-interface = { path = "../crates/module-interface", version = "0.4.1" }
 marine-utils = { path = "../crates/utils", version = "0.4.0" }
 marine-rs-sdk-main = { version = "0.6.15", features = ["logger"] }

--- a/fluence-faas/src/faas.rs
+++ b/fluence-faas/src/faas.rs
@@ -256,7 +256,7 @@ impl FluenceFaaS {
 // This API is intended for testing purposes (mostly in Marine REPL)
 #[cfg(feature = "raw-module-api")]
 impl FluenceFaaS {
-    pub fn load_module<S, C>(
+    pub fn load_module<C, S>(
         &mut self,
         name: S,
         wasm_bytes: &[u8],

--- a/fluence-faas/src/faas.rs
+++ b/fluence-faas/src/faas.rs
@@ -137,10 +137,10 @@ impl FluenceFaaS {
     }
 
     /// Call a specified function of loaded on a startup module by its name.
-    pub fn call_with_ivalues<MN: AsRef<str>, FN: AsRef<str>>(
+    pub fn call_with_ivalues(
         &mut self,
-        module_name: MN,
-        func_name: FN,
+        module_name: impl AsRef<str>,
+        func_name: impl AsRef<str>,
         args: &[IValue],
         call_parameters: marine_rs_sdk::CallParameters,
     ) -> FaaSResult<Vec<IValue>> {
@@ -152,10 +152,10 @@ impl FluenceFaaS {
     }
 
     /// Call a specified function of loaded on a startup module by its name.
-    pub fn call_with_json<MN: AsRef<str>, FN: AsRef<str>>(
+    pub fn call_with_json(
         &mut self,
-        module_name: MN,
-        func_name: FN,
+        module_name: impl AsRef<str>,
+        func_name: impl AsRef<str>,
         json_args: JValue,
         call_parameters: marine_rs_sdk::CallParameters,
     ) -> FaaSResult<JValue> {
@@ -285,13 +285,13 @@ impl FluenceFaaS {
             .map_err(Into::into)
     }
 
-    pub fn unload_module<S: AsRef<str>>(&mut self, module_name: S) -> FaaSResult<()> {
+    pub fn unload_module(&mut self, module_name: impl AsRef<str>) -> FaaSResult<()> {
         self.marine.unload_module(module_name).map_err(Into::into)
     }
 
-    pub fn module_wasi_state<S: AsRef<str>>(
+    pub fn module_wasi_state(
         &mut self,
-        module_name: S,
+        module_name: impl AsRef<str>,
     ) -> FaaSResult<&wasmer_wasi::state::WasiState> {
         let module_name = module_name.as_ref();
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-runtime"
 description = "Marine is the Fluence Compute Runtime"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2018"

--- a/runtime/src/engine.rs
+++ b/runtime/src/engine.rs
@@ -45,10 +45,10 @@ impl Marine {
     }
 
     /// Invoke a function of a module inside Marine by given function name with given arguments.
-    pub fn call<MN: AsRef<str>, FN: AsRef<str>>(
+    pub fn call(
         &mut self,
-        module_name: MN,
-        func_name: FN,
+        module_name: impl AsRef<str>,
+        func_name: impl AsRef<str>,
         arguments: &[IValue],
     ) -> MResult<Vec<IValue>> {
         let module_name = module_name.as_ref();
@@ -60,9 +60,9 @@ impl Marine {
     }
 
     /// Load a new module inside Marine.
-    pub fn load_module<S: Into<String>>(
+    pub fn load_module(
         &mut self,
-        name: S,
+        name: impl Into<String>,
         wasm_bytes: &[u8],
         config: MModuleConfig,
     ) -> MResult<()> {
@@ -89,7 +89,7 @@ impl Marine {
     }
 
     /// Unload previously loaded module.
-    pub fn unload_module<S: AsRef<str>>(&mut self, name: S) -> MResult<()> {
+    pub fn unload_module(&mut self, name: impl AsRef<str>) -> MResult<()> {
         // TODO: clean up all reference from adaptors after adding support of lazy linking
         self.modules
             .remove(name.as_ref())
@@ -97,9 +97,9 @@ impl Marine {
             .ok_or_else(|| MError::NoSuchModule(name.as_ref().to_string()))
     }
 
-    pub fn module_wasi_state<S: AsRef<str>>(
+    pub fn module_wasi_state(
         &mut self,
-        module_name: S,
+        module_name: impl AsRef<str>,
     ) -> Option<&wasmer_wasi::state::WasiState> {
         self.modules
             .get_mut(module_name.as_ref())
@@ -114,23 +114,23 @@ impl Marine {
     }
 
     /// Return function signatures exported by module with given name.
-    pub fn module_interface<S: AsRef<str>>(&self, module_name: S) -> Option<MModuleInterface<'_>> {
+    pub fn module_interface(&self, module_name: impl AsRef<str>) -> Option<MModuleInterface<'_>> {
         self.modules
             .get(module_name.as_ref())
             .map(Self::get_module_interface)
     }
 
     /// Return record types exported by module with given name.
-    pub fn module_record_types<S: AsRef<str>>(&self, module_name: S) -> Option<&MRecordTypes> {
+    pub fn module_record_types(&self, module_name: impl AsRef<str>) -> Option<&MRecordTypes> {
         self.modules
             .get(module_name.as_ref())
             .map(|module| module.export_record_types())
     }
 
     /// Return record type for supplied record id exported by module with given name.
-    pub fn module_record_type_by_id<S: AsRef<str>>(
+    pub fn module_record_type_by_id(
         &self,
-        module_name: S,
+        module_name: impl AsRef<str>,
         record_id: u64,
     ) -> Option<&Rc<IRecordType>> {
         self.modules

--- a/runtime/src/misc/prepare.rs
+++ b/runtime/src/misc/prepare.rs
@@ -36,7 +36,7 @@ struct ModuleBootstrapper {
     module: elements::Module,
 }
 
-impl<'a> ModuleBootstrapper {
+impl ModuleBootstrapper {
     fn init(module_code: &[u8]) -> PrepareResult<Self> {
         let module = elements::deserialize_buffer(module_code)?;
 

--- a/tools/repl/src/repl.rs
+++ b/tools/repl/src/repl.rs
@@ -117,7 +117,7 @@ impl REPL {
         };
         let result_msg = match self
             .app_service
-            .load_module::<String, fluence_app_service::FaaSModuleConfig>(
+            .load_module::<fluence_app_service::FaaSModuleConfig, String>(
                 module_name.into(),
                 &wasm_bytes.unwrap(),
                 Some(config),

--- a/web-runtime/src/marine_js.rs
+++ b/web-runtime/src/marine_js.rs
@@ -113,9 +113,9 @@ impl DynFunc {
                     .map(|(value, ty)| {
                         match ty {
                             WType::I32 => value.as_i64().map(|value| WValue::I32(value as i32)),
-                            WType::I64 => value.as_i64().map(|value| WValue::I64(value)),
+                            WType::I64 => value.as_i64().map(WValue::I64),
                             WType::F32 => value.as_f64().map(|value| WValue::F32(value as f32)),
-                            WType::F64 => value.as_f64().map(|value| WValue::F64(value)),
+                            WType::F64 => value.as_f64().map(WValue::F64),
                             WType::V128 => None,
                         }
                         .ok_or(format!("Cannot convert value {} to type {}", value, ty))


### PR DESCRIPTION
This changes are intended to reflect corresponding interface in the Marine Book and aims to simplify reading of the Marine interface.