### PR TITLE
feat(repl): allow partial call_parameters specification in call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "mrepl"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "check-latest",

--- a/tools/repl/Cargo.toml
+++ b/tools/repl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mrepl"
 description = "Fluence Marine REPL intended for testing purposes"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Fluence Labs"]
 repository = "https://github.com/fluencelabs/marine/tools/repl"
 license = "Apache-2.0"

--- a/tools/repl/src/repl.rs
+++ b/tools/repl/src/repl.rs
@@ -221,21 +221,13 @@ impl REPL {
         let tmp_path: String = std::env::temp_dir().to_string_lossy().into();
         let service_id = uuid::Uuid::new_v4().to_string();
 
-        let config_file_path: Option<PathBuf> = config_file_path.map(Into::into);
-
         let start = Instant::now();
 
         let mut config = config_file_path
-            .as_ref()
-            .map(|p| TomlAppServiceConfig::load(p))
+            .map(|p| TomlAppServiceConfig::load(p.into()))
             .transpose()?
             .unwrap_or_default();
         config.service_base_dir = Some(tmp_path);
-
-        config.toml_marine_config.base_path = config_file_path
-            .map(|path| path.parent().map(PathBuf::from))
-            .flatten()
-            .unwrap_or_default();
 
         let app_service = AppService::new_with_empty_facade(config, &service_id, HashMap::new())?;
 


### PR DESCRIPTION
This change is useful for service development, when user needs to test functionality that relies only on part of the call parameters.