### PR TITLE
fix(repl): crash when given relative path to config in non-current directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "mrepl"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "check-latest",

--- a/tools/repl/Cargo.toml
+++ b/tools/repl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mrepl"
 description = "Fluence Marine REPL intended for testing purposes"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["Fluence Labs"]
 repository = "https://github.com/fluencelabs/marine/tools/repl"
 license = "Apache-2.0"

--- a/tools/repl/src/repl.rs
+++ b/tools/repl/src/repl.rs
@@ -231,7 +231,7 @@ impl REPL {
             .unwrap_or_default();
         config.service_base_dir = Some(tmp_path);
 
-        cfig.toml_marine_config.base_path = config_file_path
+        config.toml_marine_config.base_path = config_file_path
             .and_then(|path| path.parent().map(PathBuf::from))
             .unwrap_or_default();
 

--- a/tools/repl/src/repl.rs
+++ b/tools/repl/src/repl.rs
@@ -231,9 +231,8 @@ impl REPL {
             .unwrap_or_default();
         config.service_base_dir = Some(tmp_path);
 
-        config.toml_marine_config.base_path = config_file_path
-            .map(|path| path.parent().map(PathBuf::from))
-            .flatten()
+        cfig.toml_marine_config.base_path = config_file_path
+            .and_then(|path| path.parent().map(PathBuf::from))
             .unwrap_or_default();
 
         let app_service = AppService::new_with_empty_facade(config, &service_id, HashMap::new())?;

--- a/tools/repl/src/repl.rs
+++ b/tools/repl/src/repl.rs
@@ -220,14 +220,21 @@ impl REPL {
     ) -> ReplResult<AppService> {
         let tmp_path: String = std::env::temp_dir().to_string_lossy().into();
         let service_id = uuid::Uuid::new_v4().to_string();
+        let config_file_path: Option<PathBuf> = config_file_path.map(Into::into);
 
         let start = Instant::now();
 
         let mut config = config_file_path
-            .map(|p| TomlAppServiceConfig::load(p.into()))
+            .as_ref()
+            .map(|p| TomlAppServiceConfig::load(p))
             .transpose()?
             .unwrap_or_default();
         config.service_base_dir = Some(tmp_path);
+
+        config.toml_marine_config.base_path = config_file_path
+            .map(|path| path.parent().map(PathBuf::from))
+            .flatten()
+            .unwrap_or_default();
 
         let app_service = AppService::new_with_empty_facade(config, &service_id, HashMap::new())?;
 


### PR DESCRIPTION
Mrepl wasnt able to process config when used in such commands:
```
mrepl some/dir/Config.toml
```

This PR fixes crash, supporting this behaviour fully.