### PR TITLE
ci: remove `cargo update` from workflows

### DIFF
--- a/.github/workflows/marine.yml
+++ b/.github/workflows/marine.yml
@@ -43,9 +43,6 @@ jobs:
         run: ./build.sh
         working-directory: marine-js
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Install marine-js npm dependencies
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/marine.yml
+++ b/.github/workflows/marine.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
-        -
+
       - name: Install marine-js npm dependencies
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/marine.yml
+++ b/.github/workflows/marine.yml
@@ -43,6 +43,9 @@ jobs:
         run: ./build.sh
         working-directory: marine-js
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        -
       - name: Install marine-js npm dependencies
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/publish_npm_dev.yml
+++ b/.github/workflows/publish_npm_dev.yml
@@ -33,8 +33,6 @@ jobs:
       - name: Setup rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - run: cargo update --aggressive
-
       ### Calculate FINAL_VERSION
       - name: Install jq & sponge
         run: sudo apt-get update && sudo apt-get --yes --force-yes install jq moreutils

--- a/.github/workflows/publish_npm_dev.yml
+++ b/.github/workflows/publish_npm_dev.yml
@@ -125,6 +125,3 @@ jobs:
         working-directory: marine-js/npm-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/publish_npm_dev.yml
+++ b/.github/workflows/publish_npm_dev.yml
@@ -127,3 +127,6 @@ jobs:
         working-directory: marine-js/npm-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/publish_npm_release.yml
+++ b/.github/workflows/publish_npm_release.yml
@@ -23,8 +23,6 @@ jobs:
       - name: Setup rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - run: cargo update --aggressive
-
       ### Calculate FINAL_VERSION
       - name: Install jq & sponge
         run: sudo apt-get update && sudo apt-get --yes --force-yes install jq moreutils

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -20,8 +20,6 @@ jobs:
       - name: Setup rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - run: cargo update --aggressive
-
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
 


### PR DESCRIPTION
`cargo update` changed the source code of marine-js and thus wasm-pack generated export ids different from ones that are generated locally, and so published package was not working