### PR TITLE
chore(marine-js): Pin browser-or-node to 2.0.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   ],
   "enabledManagers": ["cargo", "npm", "github-actions"],
   "schedule": "every weekend",
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "matchDepTypes": ["devDependencies"],

--- a/marine-js/npm-package/package-lock.json
+++ b/marine-js/npm-package/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@wasmer/wasi": "^0.12.0",
                 "@wasmer/wasmfs": "^0.12.0",
-                "browser-or-node": "^2.0.0",
+                "browser-or-node": "2.0.0",
                 "buffer": "^6.0.3",
                 "threads": "^1.7.0",
                 "ts-jest": "^27.1.4"

--- a/marine-js/npm-package/package.json
+++ b/marine-js/npm-package/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@wasmer/wasi": "^0.12.0",
         "@wasmer/wasmfs": "^0.12.0",
-        "browser-or-node": "^2.0.0",
+        "browser-or-node": "2.0.0",
         "buffer": "^6.0.3",
         "threads": "^1.7.0",
         "ts-jest": "^27.1.4"


### PR DESCRIPTION
https://github.com/flexdinesh/browser-or-node/issues/22