### PR TITLE
chore(ci): Notify on release failures and other small CI changes [fixes FLU-222, FLU-41 and FLU-196]

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,10 @@
   "rangeStrategy": "pin",
   "packageRules": [
     {
+      "matchPackagePatterns": ["^@wasmer", "^wasmer", "^wasm-bindgen"],
+      "enabled": false
+    },
+    {
       "matchDepTypes": ["devDependencies"],
       "prPriority": -1
     },
@@ -17,14 +21,8 @@
       "prConcurrentLimit": 1
     },
     {
-      "matchManagers": [ "github-actions" ],
-      "automerge": true,
-      "automergeType": "branch",
+      "matchManagers": ["github-actions"],
       "prPriority": 1
-    },
-    {
-      "matchPackagePatterns": ["^@wasmer", "^wasmer", "^wasm-bindgen"],
-      "enabled": false
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "marine"
+name: "Run tests"
 
 on:
   pull_request:
@@ -15,9 +15,10 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  marine:
-    name: "Run tests"
+  tests:
+    name: "marine / cargo and marine-js"
     runs-on: builder
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -196,7 +196,7 @@ jobs:
       - uses: lwhiteley/dependent-jobs-result-check@v1
         id: status
         with:
-          statuses: failure,cancelled
+          statuses: failure,cancelled,skipped
           dependencies: ${{ toJSON(needs) }}
 
       - name: Log output

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -183,3 +183,28 @@ jobs:
       marine-version: "${{ needs.marine.outputs.cargo-version }}"
       mrepl-version: "${{ needs.marine.outputs.cargo-version }}"
       rust-peer-image: "${{ needs.rust-peer.outputs.rust-peer-image }}"
+
+  status:
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - fluence-cli
+      - registry
+      - aqua-playground
+
+    steps:
+      - uses: lwhiteley/dependent-jobs-result-check@v1
+        id: status
+        with:
+          statuses: failure,cancelled
+          dependencies: ${{ toJSON(needs) }}
+
+      - name: Log output
+        run: |
+          echo "statuses:" "${{ steps.status.outputs.statuses }}"
+          echo "jobs:" "${{ steps.status.outputs.jobs }}"
+          echo "found any?:" "${{ steps.status.outputs.found }}"
+
+      - name: Fail run
+        if: fromJSON(steps.status.outputs.found)
+        run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
+          registry-url: "https://registry.npmjs.org"
 
       - run: npm i
         working-directory: marine-js/npm-package
@@ -148,3 +149,51 @@ jobs:
       - name: Publish to npm registry
         run: npm publish --access public
         working-directory: marine-js/npm-package
+
+  slack:
+    if: always()
+    name: "Notify"
+    runs-on: ubuntu-latest
+
+    needs:
+      - release-please
+      - crates
+      - marine-js
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: lwhiteley/dependent-jobs-result-check@v1
+        id: status
+        with:
+          statuses: failure
+          dependencies: ${{ toJSON(needs) }}
+
+      - name: Log output
+        run: |
+          echo "statuses:" "${{ steps.status.outputs.statuses }}"
+          echo "jobs:" "${{ steps.status.outputs.jobs }}"
+          echo "found any?:" "${{ steps.status.outputs.found }}"
+
+      - name: Import secrets
+        uses: hashicorp/vault-action@v2.4.3
+        with:
+          url: https://vault.fluence.dev
+          path: jwt/github
+          role: ci
+          method: jwt
+          jwtGithubAudience: "https://github.com/fluencelabs"
+          jwtTtl: 300
+          exportToken: false
+          secrets: |
+            kv/slack/release-please webhook | SLACK_WEBHOOK_URL
+
+      - uses: ravsamhq/notify-slack-action@v2
+        if: steps.status.outputs.found
+        with:
+          status: "failure"
+          notification_title: "*{workflow}* has {status_message}"
+          message_format: "${{ steps.status.outputs.jobs }} {status_message} in <{repo_url}|{repo}>"
+          footer: "<{run_url}>"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - release-please
 
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
             kv/slack/release-please webhook | SLACK_WEBHOOK_URL
 
       - uses: ravsamhq/notify-slack-action@v2
-        if: steps.status.outputs.found
+        if: steps.status.outputs.found == true
         with:
           status: "failure"
           notification_title: "*{workflow}* has {status_message}"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,6 +14,7 @@ jobs:
   cargo-snapshot:
     name: "Publish cargo snapshots"
     runs-on: builder
+    timeout-minutes: 60
 
     outputs:
       version: "${{ steps.snapshot.outputs.version }}"
@@ -57,6 +58,7 @@ jobs:
   # publish-marine-js:
   #   name: "Publish @fluencelabs/marine-js snapshot"
   #   runs-on: builder
+  #   timemout-minutes: 60
 
   #   outputs:
   #     version: "${{ steps.snapshot.outputs.version }}"


### PR DESCRIPTION
Please add `e2e / status` to required checks

- notify on release failure to slack
- run renovate any time for fluencelabs dependencies and use prefix fix(deps) for them
- add `e2e / status` check that should be set as required for PR before merge (please do it in settings before merge)