### PR TITLE
chore(ci): Build marine and mrepl binaries for macos and linux

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -1,0 +1,126 @@
+name: "Build binaries"
+
+on:
+  workflow_call:
+    inputs:
+      binary:
+        description: "binary to build"
+        type: string
+        required: true
+      tag:
+        description: "tag name to appload binaries to"
+        type: string
+        required: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+          # - arch: aarch64
+    container:
+      image: messense/rust-musl-cross:${{ matrix.arch }}-musl
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build ${{ inputs.binary }}
+        run: cargo build -p ${{ inputs.binary }} --release
+
+      - name: Prepare binary for upload
+        id: prepare
+        env:
+          BIN: "${{ inputs.binary }}-linux-${{ matrix.arch }}"
+        run: |
+          mv target/${{ matrix.arch }}-unknown-linux-musl/release/${{ inputs.binary }} ${BIN}
+          echo "bin=${BIN}" >> $GITHUB_OUTPUT
+
+      - name: Upload binary to checks
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.prepare.outputs.bin }}-artifact
+          path: ${{ steps.prepare.outputs.bin }}
+
+  macos:
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.arch }}-apple-darwin
+      MACOS_SDK: "macosx12.3"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Prepare build variables
+        run: |
+          sudo xcode-select -switch /Applications/Xcode_13.4.1.app
+          SDKROOT=$(xcrun -sdk ${{ env.MACOS_SDK }} --show-sdk-path)
+          MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk ${{ env.MACOS_SDK }} --show-sdk-platform-version)
+
+          echo "SDKROOT=${SKDROOT}" >> $GITHUB_ENV
+          echo "MACOSX_DEPLOYMENT_TARGET=${SKDROOT}" >> $GITHUB_ENV
+
+      - name: Setup rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Build ${{ inputs.binary }}
+        run: cargo build -p ${{ inputs.binary }} --release
+
+      - name: Prepare binary for upload
+        id: prepare
+        env:
+          BIN: "${{ inputs.binary }}-darwin-${{ matrix.arch }}"
+        run: |
+          mv target/${{ matrix.arch }}-apple-darwin/release/${{ inputs.binary }} ${BIN}
+          echo "bin=${BIN}" >> $GITHUB_OUTPUT
+
+      - name: Upload binary to checks
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.prepare.outputs.bin }}-artifact
+          path: ${{ steps.prepare.outputs.bin }}
+
+  upload:
+    name: "Upload ${{ inputs.binary }}"
+    runs-on: ubuntu-latest
+    needs:
+      - linux
+      - macos
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          path: binaries/
+
+      - name: Generate checksums
+        id: sum
+        run: |
+          ls -R
+          mv */* .
+          rmdir *-artifact
+          sha256sum * | tee > ${{ inputs.binary }}_SHA256_SUMS
+        working-directory: binaries
+
+      - name: Upload binaries
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            binaries/*
+          tag_name: ${{ inputs.tag }}

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -8,7 +8,7 @@ on:
         type: string
         required: true
       tag:
-        description: "tag name to appload binaries to"
+        description: "tag name to upload binaries to"
         type: string
         required: true
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Lint actions
         uses: reviewdog/action-actionlint@v1
         env:
-          SHELLCHECK_OPTS: "-e SC2086 -e SC2207 -e SC2128"
+          SHELLCHECK_OPTS: "-e SC2086 -e SC2207 -e SC2128 -e SC2034 -e SC2035"
         with:
           reporter: github-pr-check
           fail_on_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,24 +126,27 @@ jobs:
             --skip-published \
             --yes
 
-      - name: Build release binaries of marine & mrepl
-        run: cargo build --release -p marine -p mrepl
+  marine:
+    name: Build marine
+    needs: release-please
+    if: needs.release-please.outputs.marine-release-created
+    permissions:
+      contents: write
+    uses: ./.github/workflows/binary.yml
+    with:
+      binary: marine
+      tag: ${{ needs.release-please.outputs.marine-tag-name }}
 
-      - name: Upload marine binary
-        if: needs.release-please.outputs.marine-release-created
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            target/release/marine
-          tag_name: ${{ needs.release-please.outputs.marine-tag-name }}
-
-      - name: Upload mrepl binary
-        if: needs.release-please.outputs.mrepl-release-created
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            target/release/mrepl
-          tag_name: ${{ needs.release-please.outputs.mrepl-tag-name }}
+  mrepl:
+    name: Build
+    needs: release-please
+    if: needs.release-please.outputs.mrepl-release-created
+    permissions:
+      contents: write
+    uses: ./.github/workflows/binary.yml
+    with:
+      binary: mrepl
+      tag: ${{ needs.release-please.outputs.mrepl-tag-name }}
 
   marine-js:
     if: needs.release-please.outputs.marine-js-release-created

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,9 @@
 [toolchain]
 channel = "nightly-2022-09-15"
-targets = [ "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-wasi", "wasm32-unknown-unknown" ]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "x86_64-apple-darwin",
+  "wasm32-wasi",
+  "wasm32-unknown-unknown",
+]


### PR DESCRIPTION
Should look something like this (`<binary>-<platform>-<arch>`)
![image](https://user-images.githubusercontent.com/28529663/218147327-49763a91-bbcf-4ebc-a2ba-162b25cd172e.png)
With ability to add more platforms/arches later in one line.