### PR TITLE
fix(release-please): Get rid of workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,6 @@ members = [
     "tools/repl",
 ]
 
-[workspace.dependencies]
-wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
-it-memory-traits ="0.4.0"
-it-lilo = "0.5.1"
-fluence-it-types = { version = "0.4.1", features = ["impls"] }
-
 [profile.release]
 opt-level = 3
 debug = false

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,9 +21,9 @@ marine-min-it-version =  { path = "../crates/min-it-version", version = "0.3.0" 
 marine-wasm-backend-traits = {path = "../crates/wasm-backend-traits", version = "0.2.0"}
 marine-wasmtime-backend = { path = "../crates/wasmtime-backend", version = "0.2.1"}
 
-wasmer-it = { workspace = true }
-it-lilo = { workspace = true }
-it-memory-traits = { workspace = true }
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
+it-lilo = "0.5.1"
+it-memory-traits = "0.4.0"
 bytesize = "1.1.0"
 
 multimap = "0.8.3"

--- a/crates/it-generator/Cargo.toml
+++ b/crates/it-generator/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/lib.rs"
 marine-it-parser = { path = "../it-parser", version = "0.12.0" }
 marine-macro-impl = "0.7.1"
 
-wasmer-it = { workspace = true }
-it-lilo = { workspace = true}
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
+it-lilo = "0.5.1"
 
 thiserror = "1.0.37"
 walrus = "0.19.0"

--- a/crates/it-interfaces/Cargo.toml
+++ b/crates/it-interfaces/Cargo.toml
@@ -11,5 +11,5 @@ name = "marine_it_interfaces"
 path = "src/lib.rs"
 
 [dependencies]
-wasmer-it = { workspace = true}
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
 multimap = "0.8.3"

--- a/crates/it-json-serde/Cargo.toml
+++ b/crates/it-json-serde/Cargo.toml
@@ -11,7 +11,7 @@ name = "it_json_serde"
 path = "src/lib.rs"
 
 [dependencies]
-wasmer-it = { workspace = true}
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
 
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"

--- a/crates/it-parser/Cargo.toml
+++ b/crates/it-parser/Cargo.toml
@@ -17,7 +17,7 @@ marine-wasm-backend-traits = { path = "../wasm-backend-traits", version = "0.2.0
 
 anyhow = "1.0.66"
 walrus = "0.19.0"
-wasmer-it = { workspace = true }
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
 nom = "7.1"
 
 itertools = "0.10.5"

--- a/crates/module-interface/Cargo.toml
+++ b/crates/module-interface/Cargo.toml
@@ -15,7 +15,7 @@ marine-it-interfaces = { path = "../it-interfaces", version = "0.8.0" }
 
 anyhow = "1.0.66"
 walrus = "0.19.0"
-wasmer-it = { workspace = true }
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
 nom = "7.1.3"
 
 itertools = "0.10.5"

--- a/crates/wasm-backend-traits/Cargo.toml
+++ b/crates/wasm-backend-traits/Cargo.toml
@@ -7,8 +7,8 @@ license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-wasmer-it = { workspace = true }
-it-memory-traits = { workspace = true }
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
+it-memory-traits = "0.4.0"
 
 thiserror = "1.0.24"
 anyhow = "1.0.68"

--- a/crates/wasmtime-backend/Cargo.toml
+++ b/crates/wasmtime-backend/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 
 [dependencies]
 marine-wasm-backend-traits = {path = "../wasm-backend-traits", version = "0.2.0"}
-wasmer-it = { workspace = true }
-it-memory-traits = { workspace = true }
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
+it-memory-traits = "0.4.0"
 
 # all default features except async
 wasmtime = {version = "6.0.1", default-features = false, features = ["cache", "wat", "jitdump", "parallel-compilation", "cranelift", "pooling-allocator", "vtune"]}

--- a/marine-js/Cargo.toml
+++ b/marine-js/Cargo.toml
@@ -17,10 +17,10 @@ marine-min-it-version = { path = "../crates/min-it-version", version = "0.3.0" }
 it-json-serde = { path = "../crates/it-json-serde", version = "0.4.0" }
 
 marine-rs-sdk = "0.7.1"
-wasmer-it = { workspace = true}
-it-memory-traits = { workspace = true}
-fluence-it-types = { workspace = true }
-it-lilo = { workspace = true }
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
+it-memory-traits = "0.4.0"
+fluence-it-types = { version = "0.4.1", features = ["impls"] }
+it-lilo = "0.5.1"
 
 wasm-bindgen = "0.2"
 nom = "7.1"

--- a/marine/Cargo.toml
+++ b/marine/Cargo.toml
@@ -20,8 +20,8 @@ it-json-serde = { path = "../crates/it-json-serde", version = "0.4.0" }
 marine-wasm-backend-traits = { path = "../crates/wasm-backend-traits", version = "0.2.0"}
 marine-wasmtime-backend = { path = "../crates/wasmtime-backend", version = "0.2.1"}
 
-wasmer-it = { workspace = true }
-it-memory-traits = { workspace = true }
+wasmer-it = { package = "wasmer-interface-types-fl", version = "0.26.1" }
+it-memory-traits = "0.4.0"
 
 toml = "0.5.9"
 serde = { version = "1.0.147", features = ["derive"] }


### PR DESCRIPTION
When workspace.dependencies updated packages that use that dependencies are not bumped by release-please.
https://github.com/googleapis/release-please/issues/1896

This is a temporary workaround until it is fixed in release-please.