### PR TITLE
feat(deps)!: update marine-rs-sdk-to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "marine-module-info-parser"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "marine-runtime"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bytesize",
  "env_logger 0.10.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f768393e7fabd388fe8409b13faa4d93ab0fef35db1508438dfdb066918bcf38"
 name = "arguments-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
  "safe-transmute",
 ]
 
@@ -104,7 +104,7 @@ dependencies = [
 name = "arrays-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
  "safe-transmute",
 ]
 
@@ -236,7 +236,7 @@ dependencies = [
 name = "call_parameters"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ name = "curl_adapter"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
@@ -900,7 +900,7 @@ dependencies = [
 name = "donkey"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
@@ -1002,7 +1002,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
@@ -1527,7 +1527,7 @@ name = "ipfs-effector"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
@@ -1535,7 +1535,7 @@ name = "ipfs-pure"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 name = "lilo-after-2gb-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
  "safe-transmute",
 ]
 
@@ -1696,7 +1696,7 @@ name = "local_storage"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
  "wasm-tracing-allocator",
 ]
 
@@ -2537,7 +2537,7 @@ dependencies = [
 name = "record-effector"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
  "test-record",
 ]
 
@@ -2545,7 +2545,7 @@ dependencies = [
 name = "record-pure"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
  "test-record",
 ]
 
@@ -2553,7 +2553,7 @@ dependencies = [
 name = "records-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
  "safe-transmute",
 ]
 
@@ -3019,7 +3019,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 name = "shrek"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
@@ -3227,7 +3227,7 @@ dependencies = [
 name = "test-record"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
@@ -3730,7 +3730,7 @@ dependencies = [
 name = "wasi-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
  "safe-transmute",
 ]
 
@@ -3832,14 +3832,14 @@ dependencies = [
 name = "wasm-failing"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
 name = "wasm-greeting"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f768393e7fabd388fe8409b13faa4d93ab0fef35db1508438dfdb066918bcf38"
 name = "arguments-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -104,7 +104,7 @@ dependencies = [
 name = "arrays-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -236,7 +236,7 @@ dependencies = [
 name = "call_parameters"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ name = "curl_adapter"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -900,7 +900,7 @@ dependencies = [
 name = "donkey"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1002,7 +1002,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1073,7 +1073,7 @@ dependencies = [
 
 [[package]]
 name = "fluence-app-service"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "log",
  "maplit",
@@ -1527,7 +1527,7 @@ name = "ipfs-effector"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1535,7 +1535,7 @@ name = "ipfs-pure"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 name = "lilo-after-2gb-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -1696,7 +1696,7 @@ name = "local_storage"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-tracing-allocator",
 ]
 
@@ -1759,8 +1759,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-call-parameters"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "marine-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "serde",
+]
+
+[[package]]
 name = "marine-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1885,6 +1895,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd5d4c95570c141d4a92e8c08d6253788154315a66bb3c89d266f0825e9b49db"
+dependencies = [
+ "marine-macro-impl 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk-main 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "marine-macro"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "marine-macro-impl 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+]
+
+[[package]]
 name = "marine-macro-impl"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1940,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-macro-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91ed66c39016565a422807dd3fe3fbc3c36ee88d2f0b69c2e6345168b7d9320"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "marine-macro-impl"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "marine-min-it-version"
 version = "0.3.0"
 dependencies = [
@@ -1920,12 +1974,12 @@ dependencies = [
 
 [[package]]
 name = "marine-module-info-parser"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
  "derivative",
- "marine-rs-sdk-main 0.8.1",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
  "marine-wasm-backend-traits",
  "semver",
  "serde",
@@ -1957,20 +2011,31 @@ dependencies = [
  "marine-macro 0.7.1",
  "marine-rs-sdk-main 0.7.1",
  "marine-timestamp-macro 0.7.1",
- "polyplets 0.3.3",
+ "polyplets",
  "serde",
 ]
 
 [[package]]
 name = "marine-rs-sdk"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11991d31bf4d53651e1c151637f260c759eb9f28ecf8c894eb260b50f46459cc"
+checksum = "647206070db6f592f6a9783b1326c1b6a535c739d5238e478a9fa8529234ad70"
 dependencies = [
- "marine-macro 0.8.1",
- "marine-rs-sdk-main 0.8.1",
- "marine-timestamp-macro 0.8.1",
- "polyplets 0.4.0",
+ "marine-macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk-main 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-timestamp-macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "marine-rs-sdk"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "marine-call-parameters",
+ "marine-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-timestamp-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
  "serde",
 ]
 
@@ -1995,8 +2060,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-rs-sdk-main"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69e17cc63a434d19ca9c312a29a1e06847758041f8429f333d3a91469f62594"
+dependencies = [
+ "log",
+ "serde",
+]
+
+[[package]]
+name = "marine-rs-sdk-main"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "marine-runtime"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bytesize",
  "env_logger 0.10.0",
@@ -2006,8 +2090,8 @@ dependencies = [
  "log",
  "marine-core",
  "marine-module-interface",
- "marine-rs-sdk 0.8.1",
- "marine-rs-sdk-main 0.8.1",
+ "marine-rs-sdk 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
  "marine-utils",
  "marine-wasm-backend-traits",
  "marine-wasmtime-backend",
@@ -2046,9 +2130,18 @@ dependencies = [
 
 [[package]]
 name = "marine-timestamp-macro"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d254ea11e35cdeccc62ffccf78775c066750c9e5bae4934eb0758187442282"
+checksum = "c33b9d6dd721e2d55e3737a4ba5374887cef56caa80b0a49849a06b0f2e46a4e"
+dependencies = [
+ "chrono",
+ "quote",
+]
+
+[[package]]
+name = "marine-timestamp-macro"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
 dependencies = [
  "chrono",
  "quote",
@@ -2168,7 +2261,7 @@ dependencies = [
  "fluence-app-service",
  "itertools",
  "log",
- "marine-rs-sdk-main 0.8.1",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
  "marine-wasm-backend-traits",
  "rustop",
  "rustyline",
@@ -2417,17 +2510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyplets"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b579a79a461ca50abb202eac61c76d8782fdf091a91775c9e181352e7cd30a8b"
-dependencies = [
- "marine-macro 0.8.1",
- "marine-rs-sdk-main 0.8.1",
- "serde",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,7 +2618,7 @@ dependencies = [
 name = "record-effector"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-record",
 ]
 
@@ -2544,7 +2626,7 @@ dependencies = [
 name = "record-pure"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-record",
 ]
 
@@ -2552,7 +2634,7 @@ dependencies = [
 name = "records-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -3018,7 +3100,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 name = "shrek"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3226,7 +3308,7 @@ dependencies = [
 name = "test-record"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3729,7 +3811,7 @@ dependencies = [
 name = "wasi-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -3831,14 +3913,14 @@ dependencies = [
 name = "wasm-failing"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.8.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-greeting"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.8.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3846,14 +3928,14 @@ name = "wasm-greeting-record"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-sqlite-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "marine-sqlite-connector",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f768393e7fabd388fe8409b13faa4d93ab0fef35db1508438dfdb066918bcf38"
 name = "arguments-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -104,7 +104,7 @@ dependencies = [
 name = "arrays-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -236,7 +236,7 @@ dependencies = [
 name = "call_parameters"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ name = "curl_adapter"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -889,7 +889,7 @@ dependencies = [
 name = "donkey"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -991,7 +991,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "fluence-app-service"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "log",
  "maplit",
@@ -1516,7 +1516,7 @@ name = "ipfs-effector"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1524,7 +1524,7 @@ name = "ipfs-pure"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1658,7 +1658,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 name = "lilo-after-2gb-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -1685,7 +1685,7 @@ name = "local_storage"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-tracing-allocator",
 ]
 
@@ -1748,8 +1748,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-call-parameters"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "marine-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "serde",
+]
+
+[[package]]
 name = "marine-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1879,8 +1889,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5d4c95570c141d4a92e8c08d6253788154315a66bb3c89d266f0825e9b49db"
 dependencies = [
- "marine-macro-impl 0.9.0",
- "marine-rs-sdk-main 0.9.0",
+ "marine-macro-impl 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk-main 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "marine-macro"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "marine-macro-impl 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
 ]
 
 [[package]]
@@ -1923,6 +1942,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-macro-impl"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "marine-min-it-version"
 version = "0.3.0"
 dependencies = [
@@ -1936,7 +1967,7 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
- "marine-rs-sdk-main 0.9.0",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
  "marine-wasm-backend-traits",
  "semver",
  "serde",
@@ -1978,9 +2009,21 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "647206070db6f592f6a9783b1326c1b6a535c739d5238e478a9fa8529234ad70"
 dependencies = [
- "marine-macro 0.9.0",
- "marine-rs-sdk-main 0.9.0",
- "marine-timestamp-macro 0.9.0",
+ "marine-macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk-main 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-timestamp-macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+]
+
+[[package]]
+name = "marine-rs-sdk"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "marine-call-parameters",
+ "marine-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-timestamp-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
  "serde",
 ]
 
@@ -2015,6 +2058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-rs-sdk-main"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+dependencies = [
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "marine-runtime"
 version = "0.30.0"
 dependencies = [
@@ -2026,8 +2078,8 @@ dependencies = [
  "log",
  "marine-core",
  "marine-module-interface",
- "marine-rs-sdk 0.9.0",
- "marine-rs-sdk-main 0.9.0",
+ "marine-rs-sdk 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
  "marine-utils",
  "marine-wasm-backend-traits",
  "marine-wasmtime-backend",
@@ -2069,6 +2121,15 @@ name = "marine-timestamp-macro"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33b9d6dd721e2d55e3737a4ba5374887cef56caa80b0a49849a06b0f2e46a4e"
+dependencies = [
+ "chrono",
+ "quote",
+]
+
+[[package]]
+name = "marine-timestamp-macro"
+version = "0.9.0"
+source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
 dependencies = [
  "chrono",
  "quote",
@@ -2188,7 +2249,7 @@ dependencies = [
  "fluence-app-service",
  "itertools",
  "log",
- "marine-rs-sdk-main 0.9.0",
+ "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
  "marine-wasm-backend-traits",
  "rustop",
  "rustyline",
@@ -2545,7 +2606,7 @@ dependencies = [
 name = "record-effector"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-record",
 ]
 
@@ -2553,7 +2614,7 @@ dependencies = [
 name = "record-pure"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "test-record",
 ]
 
@@ -2561,7 +2622,7 @@ dependencies = [
 name = "records-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -3027,7 +3088,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 name = "shrek"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3235,7 +3296,7 @@ dependencies = [
 name = "test-record"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3738,7 +3799,7 @@ dependencies = [
 name = "wasi-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "safe-transmute",
 ]
 
@@ -3840,14 +3901,14 @@ dependencies = [
 name = "wasm-failing"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-greeting"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3855,14 +3916,14 @@ name = "wasm-greeting-record"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasm-sqlite-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "marine-sqlite-connector",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f768393e7fabd388fe8409b13faa4d93ab0fef35db1508438dfdb066918bcf38"
 name = "arguments-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -104,7 +104,7 @@ dependencies = [
 name = "arrays-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -236,7 +236,7 @@ dependencies = [
 name = "call_parameters"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ name = "curl_adapter"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -889,7 +889,7 @@ dependencies = [
 name = "donkey"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -991,7 +991,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -1516,7 +1516,7 @@ name = "ipfs-effector"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -1524,7 +1524,7 @@ name = "ipfs-pure"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -1658,7 +1658,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 name = "lilo-after-2gb-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -1685,7 +1685,7 @@ name = "local_storage"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "wasm-tracing-allocator",
 ]
 
@@ -1874,6 +1874,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-macro"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd5d4c95570c141d4a92e8c08d6253788154315a66bb3c89d266f0825e9b49db"
+dependencies = [
+ "marine-macro-impl 0.9.0",
+ "marine-rs-sdk-main 0.9.0",
+]
+
+[[package]]
 name = "marine-macro-impl"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1910,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-macro-impl"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91ed66c39016565a422807dd3fe3fbc3c36ee88d2f0b69c2e6345168b7d9320"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "marine-min-it-version"
 version = "0.3.0"
 dependencies = [
@@ -1913,7 +1936,7 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
- "marine-rs-sdk-main 0.8.1",
+ "marine-rs-sdk-main 0.9.0",
  "marine-wasm-backend-traits",
  "semver",
  "serde",
@@ -1945,20 +1968,19 @@ dependencies = [
  "marine-macro 0.7.1",
  "marine-rs-sdk-main 0.7.1",
  "marine-timestamp-macro 0.7.1",
- "polyplets 0.3.3",
+ "polyplets",
  "serde",
 ]
 
 [[package]]
 name = "marine-rs-sdk"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11991d31bf4d53651e1c151637f260c759eb9f28ecf8c894eb260b50f46459cc"
+checksum = "647206070db6f592f6a9783b1326c1b6a535c739d5238e478a9fa8529234ad70"
 dependencies = [
- "marine-macro 0.8.1",
- "marine-rs-sdk-main 0.8.1",
- "marine-timestamp-macro 0.8.1",
- "polyplets 0.4.0",
+ "marine-macro 0.9.0",
+ "marine-rs-sdk-main 0.9.0",
+ "marine-timestamp-macro 0.9.0",
  "serde",
 ]
 
@@ -1983,6 +2005,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "marine-rs-sdk-main"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69e17cc63a434d19ca9c312a29a1e06847758041f8429f333d3a91469f62594"
+dependencies = [
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "marine-runtime"
 version = "0.29.0"
 dependencies = [
@@ -1994,8 +2026,8 @@ dependencies = [
  "log",
  "marine-core",
  "marine-module-interface",
- "marine-rs-sdk 0.8.1",
- "marine-rs-sdk-main 0.8.1",
+ "marine-rs-sdk 0.9.0",
+ "marine-rs-sdk-main 0.9.0",
  "marine-utils",
  "marine-wasm-backend-traits",
  "marine-wasmtime-backend",
@@ -2034,9 +2066,9 @@ dependencies = [
 
 [[package]]
 name = "marine-timestamp-macro"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d254ea11e35cdeccc62ffccf78775c066750c9e5bae4934eb0758187442282"
+checksum = "c33b9d6dd721e2d55e3737a4ba5374887cef56caa80b0a49849a06b0f2e46a4e"
 dependencies = [
  "chrono",
  "quote",
@@ -2156,7 +2188,7 @@ dependencies = [
  "fluence-app-service",
  "itertools",
  "log",
- "marine-rs-sdk-main 0.8.1",
+ "marine-rs-sdk-main 0.9.0",
  "marine-wasm-backend-traits",
  "rustop",
  "rustyline",
@@ -2405,17 +2437,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyplets"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b579a79a461ca50abb202eac61c76d8782fdf091a91775c9e181352e7cd30a8b"
-dependencies = [
- "marine-macro 0.8.1",
- "marine-rs-sdk-main 0.8.1",
- "serde",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,7 +2545,7 @@ dependencies = [
 name = "record-effector"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "test-record",
 ]
 
@@ -2532,7 +2553,7 @@ dependencies = [
 name = "record-pure"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "test-record",
 ]
 
@@ -2540,7 +2561,7 @@ dependencies = [
 name = "records-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -3006,7 +3027,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 name = "shrek"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -3214,7 +3235,7 @@ dependencies = [
 name = "test-record"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -3717,7 +3738,7 @@ dependencies = [
 name = "wasi-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -3819,14 +3840,14 @@ dependencies = [
 name = "wasm-failing"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.8.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
 name = "wasm-greeting"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.8.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -3834,14 +3855,14 @@ name = "wasm-greeting-record"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
 name = "wasm-sqlite-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.7.1",
+ "marine-rs-sdk 0.9.0",
  "marine-sqlite-connector",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "f768393e7fabd388fe8409b13faa4d93ab0fef35db1508438dfdb066918bcf38"
 name = "arguments-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -104,7 +104,7 @@ dependencies = [
 name = "arrays-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -236,7 +236,7 @@ dependencies = [
 name = "call_parameters"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ name = "curl_adapter"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -900,7 +900,7 @@ dependencies = [
 name = "donkey"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -1002,7 +1002,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -1527,7 +1527,7 @@ name = "ipfs-effector"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -1535,7 +1535,7 @@ name = "ipfs-pure"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -1669,7 +1669,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 name = "lilo-after-2gb-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -1696,7 +1696,7 @@ name = "local_storage"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "wasm-tracing-allocator",
 ]
 
@@ -1760,11 +1760,12 @@ dependencies = [
 
 [[package]]
 name = "marine-call-parameters"
-version = "0.9.0"
-source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ca0439e5b2a812d8bc5c3b7d71e3691fb260a1f0384a7e842eec1b59f13069"
 dependencies = [
- "marine-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
- "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-macro 0.10.0",
+ "marine-rs-sdk-main 0.10.0",
  "serde",
 ]
 
@@ -1876,41 +1877,22 @@ dependencies = [
 
 [[package]]
 name = "marine-macro"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e03da22f641984aad5229f780d190502196d1c0bf908d3d17f5d6bcba73e525"
-dependencies = [
- "marine-macro-impl 0.7.1",
- "marine-rs-sdk-main 0.7.1",
-]
-
-[[package]]
-name = "marine-macro"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c99fa7013660d8e129b2bcd51138015136b91903f88529f1da0510f850c28ea"
-dependencies = [
- "marine-macro-impl 0.8.1",
- "marine-rs-sdk-main 0.8.1",
-]
-
-[[package]]
-name = "marine-macro"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5d4c95570c141d4a92e8c08d6253788154315a66bb3c89d266f0825e9b49db"
 dependencies = [
- "marine-macro-impl 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-rs-sdk-main 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-macro-impl 0.9.0",
+ "marine-rs-sdk-main 0.9.0",
 ]
 
 [[package]]
 name = "marine-macro"
-version = "0.9.0"
-source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0088fc9cb6a970dc17a510c3cb28fe459c368d566e8cb7f8354e06ef3395c883"
 dependencies = [
- "marine-macro-impl 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
- "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-macro-impl 0.10.0",
+ "marine-rs-sdk-main 0.10.0",
 ]
 
 [[package]]
@@ -1918,19 +1900,6 @@ name = "marine-macro-impl"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca474b63cabaf8d7d9b38de87d630023cbc91ddc77e92f9c7bb745462a131b44"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "marine-macro-impl"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b4761eec59a2914413d1ea14659305e6374bfed69998f33763daa586c44196"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1954,8 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "marine-macro-impl"
-version = "0.9.0"
-source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e457b58c826679139896f04e6cfa38c5d23870a88e957e8e0a6f646e7c3f0ac4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1979,7 +1949,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "derivative",
- "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.10.0",
  "marine-wasm-backend-traits",
  "semver",
  "serde",
@@ -2004,58 +1974,26 @@ dependencies = [
 
 [[package]]
 name = "marine-rs-sdk"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfeeb7b8cd98e32276fabfe6ab095a6aae793f3f080e7eb1c3d36b1b762397c"
-dependencies = [
- "marine-macro 0.7.1",
- "marine-rs-sdk-main 0.7.1",
- "marine-timestamp-macro 0.7.1",
- "polyplets",
- "serde",
-]
-
-[[package]]
-name = "marine-rs-sdk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "647206070db6f592f6a9783b1326c1b6a535c739d5238e478a9fa8529234ad70"
 dependencies = [
- "marine-macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-rs-sdk-main 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "marine-timestamp-macro 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-macro 0.9.0",
+ "marine-rs-sdk-main 0.9.0",
+ "marine-timestamp-macro 0.9.0",
  "serde",
 ]
 
 [[package]]
 name = "marine-rs-sdk"
-version = "0.9.0"
-source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6ecd45528096514b4db8d23523eadaf9e5d5a7d3fce637e4bb684afccc0e9a3"
 dependencies = [
  "marine-call-parameters",
- "marine-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
- "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
- "marine-timestamp-macro 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
- "serde",
-]
-
-[[package]]
-name = "marine-rs-sdk-main"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43e6eac611bc5b96e80a3f3e2621eeded69fb56389aa83b6ea76ec0f243ef23"
-dependencies = [
- "log",
- "serde",
-]
-
-[[package]]
-name = "marine-rs-sdk-main"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01678ba2a94fcfeb8232e87281937b07927ab2a54205747b6ab45e3f5ad65fd"
-dependencies = [
- "log",
+ "marine-macro 0.10.0",
+ "marine-rs-sdk-main 0.10.0",
+ "marine-timestamp-macro 0.10.0",
  "serde",
 ]
 
@@ -2071,8 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "marine-rs-sdk-main"
-version = "0.9.0"
-source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11eabbc74c69ad11874fb6cf686604833d084633293324524a40ec581663f978"
 dependencies = [
  "log",
  "serde",
@@ -2090,8 +2029,8 @@ dependencies = [
  "log",
  "marine-core",
  "marine-module-interface",
- "marine-rs-sdk 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
- "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk 0.10.0",
+ "marine-rs-sdk-main 0.10.0",
  "marine-utils",
  "marine-wasm-backend-traits",
  "marine-wasmtime-backend",
@@ -2110,22 +2049,12 @@ dependencies = [
 
 [[package]]
 name = "marine-sqlite-connector"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ebecc037ef73b87d4e7f71d9925f0457230d22f1bdabbc5c962ec34932e88e"
+checksum = "02b2f62a0f56af2d5467d294133e264e13e24c15cfb21588f7c61c680f241baf"
 dependencies = [
  "bytesize",
- "marine-rs-sdk 0.7.1",
-]
-
-[[package]]
-name = "marine-timestamp-macro"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea4557a757e9f4d04a0b6afb047431a246963268a4cab56c62cb5355457cb2f"
-dependencies = [
- "chrono",
- "quote",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -2140,8 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "marine-timestamp-macro"
-version = "0.9.0"
-source = "git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params#de7d55e422fc8a0594d9c32debdd4613e2d478bf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf956d174fdbf940b474089d5388aa35b4fc73fedbfade2a92dc198084b9afa"
 dependencies = [
  "chrono",
  "quote",
@@ -2261,7 +2191,7 @@ dependencies = [
  "fluence-app-service",
  "itertools",
  "log",
- "marine-rs-sdk-main 0.9.0 (git+https://github.com/fluencelabs/marine-rs-sdk?branch=feat/decouple-call-params)",
+ "marine-rs-sdk-main 0.10.0",
  "marine-wasm-backend-traits",
  "rustop",
  "rustyline",
@@ -2499,17 +2429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
-name = "polyplets"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad2a1ffbc0d66f92c861bb57fb60f113ea0736d16d4cd7ead1bb514d8d8b3d3"
-dependencies = [
- "marine-macro 0.8.1",
- "marine-rs-sdk-main 0.7.1",
- "serde",
-]
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,7 +2537,7 @@ dependencies = [
 name = "record-effector"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "test-record",
 ]
 
@@ -2626,7 +2545,7 @@ dependencies = [
 name = "record-pure"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "test-record",
 ]
 
@@ -2634,7 +2553,7 @@ dependencies = [
 name = "records-passing-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -3100,7 +3019,7 @@ checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 name = "shrek"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -3308,7 +3227,7 @@ dependencies = [
 name = "test-record"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -3811,7 +3730,7 @@ dependencies = [
 name = "wasi-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "safe-transmute",
 ]
 
@@ -3913,14 +3832,14 @@ dependencies = [
 name = "wasm-failing"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
 name = "wasm-greeting"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
 ]
 
 [[package]]
@@ -3928,14 +3847,14 @@ name = "wasm-greeting-record"
 version = "0.1.0"
 dependencies = [
  "log",
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.10.0",
 ]
 
 [[package]]
 name = "wasm-sqlite-test"
 version = "0.1.0"
 dependencies = [
- "marine-rs-sdk 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "marine-rs-sdk 0.9.0",
  "marine-sqlite-connector",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 members = [
-
     "core",
     "core/tests/wasm_tests/lilo_after_2gb",
     "crates/fluence-app-service",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-core"
 description = "Core of Marine, the Fluence Wasm Runtime"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2021"
@@ -11,7 +11,7 @@ name = "marine_core"
 path = "src/lib.rs"
 
 [dependencies]
-marine-module-info-parser = { path = "../crates/module-info-parser", version = "0.8.0" }
+marine-module-info-parser = { path = "../crates/module-info-parser", version = "0.9.0" }
 marine-it-interfaces = { path = "../crates/it-interfaces", version = "0.8.1" }
 marine-it-parser = { path = "../crates/it-parser", version = "0.13.0" }
 marine-it-generator = { path = "../crates/it-generator", version = "0.11.0" }

--- a/core/tests/wasm_tests/lilo_after_2gb/Cargo.toml
+++ b/core/tests/wasm_tests/lilo_after_2gb/Cargo.toml
@@ -10,5 +10,5 @@ name = "lilo_after_2gb"
 path = "src/pure.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"
 safe-transmute = "0.11.0"

--- a/core/tests/wasm_tests/lilo_after_2gb/Cargo.toml
+++ b/core/tests/wasm_tests/lilo_after_2gb/Cargo.toml
@@ -10,5 +10,5 @@ name = "lilo_after_2gb"
 path = "src/pure.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"
 safe-transmute = "0.11.0"

--- a/crates/fluence-app-service/Cargo.toml
+++ b/crates/fluence-app-service/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fluence-app-service"
 description = "Fluence Application Service"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2021"
 
 [dependencies]
-marine-runtime = { path = "../../marine", version = "0.29.0" }
+marine-runtime = { path = "../../marine", version = "0.30.0" }
 marine-min-it-version = { path = "../../crates/min-it-version", version = "0.3.0" }
 marine-wasm-backend-traits = {path = "../wasm-backend-traits", version = "0.3.0"}
 marine-wasmtime-backend = { path = "../wasmtime-backend", version = "0.3.0"}

--- a/crates/module-info-parser/Cargo.toml
+++ b/crates/module-info-parser/Cargo.toml
@@ -11,7 +11,7 @@ name = "marine_module_info_parser"
 path = "src/lib.rs"
 
 [dependencies]
-marine-rs-sdk-main = "0.9.0"
+marine-rs-sdk-main = {version = "0.9.0", git = "https://github.com/fluencelabs/marine-rs-sdk", branch = "feat/decouple-call-params", default-features = false }
 
 marine-wasm-backend-traits = { path = "../wasm-backend-traits", version = "0.3.0"}
 

--- a/crates/module-info-parser/Cargo.toml
+++ b/crates/module-info-parser/Cargo.toml
@@ -11,7 +11,7 @@ name = "marine_module_info_parser"
 path = "src/lib.rs"
 
 [dependencies]
-marine-rs-sdk-main = "0.8.1"
+marine-rs-sdk-main = "0.9.0"
 
 marine-wasm-backend-traits = { path = "../wasm-backend-traits", version = "0.3.0"}
 

--- a/crates/module-info-parser/Cargo.toml
+++ b/crates/module-info-parser/Cargo.toml
@@ -11,7 +11,7 @@ name = "marine_module_info_parser"
 path = "src/lib.rs"
 
 [dependencies]
-marine-rs-sdk-main = {version = "0.9.0", git = "https://github.com/fluencelabs/marine-rs-sdk", branch = "feat/decouple-call-params", default-features = false }
+marine-rs-sdk-main = {version = "0.10.0", default-features = false }
 
 marine-wasm-backend-traits = { path = "../wasm-backend-traits", version = "0.3.0"}
 

--- a/crates/module-info-parser/Cargo.toml
+++ b/crates/module-info-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-module-info-parser"
 description = "Fluence Marine Wasm module info (manifest and version) parser"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2021"

--- a/examples/call_parameters/Cargo.toml
+++ b/examples/call_parameters/Cargo.toml
@@ -10,4 +10,4 @@ name = "call_parameters"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"

--- a/examples/call_parameters/Cargo.toml
+++ b/examples/call_parameters/Cargo.toml
@@ -10,4 +10,4 @@ name = "call_parameters"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"

--- a/examples/failing/Cargo.toml
+++ b/examples/failing/Cargo.toml
@@ -12,4 +12,4 @@ name = "failing"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"

--- a/examples/failing/Cargo.toml
+++ b/examples/failing/Cargo.toml
@@ -12,4 +12,4 @@ name = "failing"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.8.1"
+marine-rs-sdk = "0.9.0"

--- a/examples/greeting/Cargo.toml
+++ b/examples/greeting/Cargo.toml
@@ -12,4 +12,4 @@ name = "greeting"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.8.1"
+marine-rs-sdk = "0.9.0"

--- a/examples/greeting/Cargo.toml
+++ b/examples/greeting/Cargo.toml
@@ -12,4 +12,4 @@ name = "greeting"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"

--- a/examples/greeting_record/Cargo.toml
+++ b/examples/greeting_record/Cargo.toml
@@ -12,6 +12,6 @@ name = "greeting-record"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
 log = "0.4.8"
 

--- a/examples/greeting_record/Cargo.toml
+++ b/examples/greeting_record/Cargo.toml
@@ -12,6 +12,6 @@ name = "greeting-record"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = {version = "0.7.0", features = ["logger"]}
+marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
 log = "0.4.8"
 

--- a/examples/greeting_record/Cargo.toml
+++ b/examples/greeting_record/Cargo.toml
@@ -12,6 +12,6 @@ name = "greeting-record"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.10.0", features = ["logger"] }
 log = "0.4.8"
 

--- a/examples/ipfs-node/effector/Cargo.toml
+++ b/examples/ipfs-node/effector/Cargo.toml
@@ -10,5 +10,5 @@ name = "ipfs_effector"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
 log = "0.4.14"

--- a/examples/ipfs-node/effector/Cargo.toml
+++ b/examples/ipfs-node/effector/Cargo.toml
@@ -10,5 +10,5 @@ name = "ipfs_effector"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.7.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
 log = "0.4.14"

--- a/examples/ipfs-node/effector/Cargo.toml
+++ b/examples/ipfs-node/effector/Cargo.toml
@@ -10,5 +10,5 @@ name = "ipfs_effector"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.10.0", features = ["logger"] }
 log = "0.4.14"

--- a/examples/ipfs-node/pure/Cargo.toml
+++ b/examples/ipfs-node/pure/Cargo.toml
@@ -10,5 +10,5 @@ name = "ipfs_pure"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.10.0", features = ["logger"] }
 log = "0.4.14"

--- a/examples/ipfs-node/pure/Cargo.toml
+++ b/examples/ipfs-node/pure/Cargo.toml
@@ -10,5 +10,5 @@ name = "ipfs_pure"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.7.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
 log = "0.4.14"

--- a/examples/ipfs-node/pure/Cargo.toml
+++ b/examples/ipfs-node/pure/Cargo.toml
@@ -10,5 +10,5 @@ name = "ipfs_pure"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
 log = "0.4.14"

--- a/examples/motivational-example/donkey/Cargo.toml
+++ b/examples/motivational-example/donkey/Cargo.toml
@@ -10,4 +10,4 @@ name = "donkey"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }

--- a/examples/motivational-example/donkey/Cargo.toml
+++ b/examples/motivational-example/donkey/Cargo.toml
@@ -10,4 +10,4 @@ name = "donkey"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.7.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }

--- a/examples/motivational-example/donkey/Cargo.toml
+++ b/examples/motivational-example/donkey/Cargo.toml
@@ -10,4 +10,4 @@ name = "donkey"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.10.0", features = ["logger"] }

--- a/examples/motivational-example/shrek/Cargo.toml
+++ b/examples/motivational-example/shrek/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/main.rs"
 name = "shrek"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }

--- a/examples/motivational-example/shrek/Cargo.toml
+++ b/examples/motivational-example/shrek/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/main.rs"
 name = "shrek"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.10.0", features = ["logger"] }

--- a/examples/motivational-example/shrek/Cargo.toml
+++ b/examples/motivational-example/shrek/Cargo.toml
@@ -10,4 +10,4 @@ path = "src/main.rs"
 name = "shrek"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.7.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }

--- a/examples/records/effector/Cargo.toml
+++ b/examples/records/effector/Cargo.toml
@@ -10,5 +10,5 @@ name = "records_effector"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"
 test-record = { path = "../test-record" }

--- a/examples/records/effector/Cargo.toml
+++ b/examples/records/effector/Cargo.toml
@@ -10,5 +10,5 @@ name = "records_effector"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"
 test-record = { path = "../test-record" }

--- a/examples/records/pure/Cargo.toml
+++ b/examples/records/pure/Cargo.toml
@@ -10,5 +10,5 @@ name = "records_pure"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"
 test-record = { path = "../test-record" }

--- a/examples/records/pure/Cargo.toml
+++ b/examples/records/pure/Cargo.toml
@@ -10,5 +10,5 @@ name = "records_pure"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"
 test-record = { path = "../test-record" }

--- a/examples/records/test-record/Cargo.toml
+++ b/examples/records/test-record/Cargo.toml
@@ -10,4 +10,4 @@ name = "test_record"
 path = "src/test_record.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"

--- a/examples/records/test-record/Cargo.toml
+++ b/examples/records/test-record/Cargo.toml
@@ -10,4 +10,4 @@ name = "test_record"
 path = "src/test_record.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -11,4 +11,4 @@ path = "src/main.rs"
 
 [dependencies]
 marine-rs-sdk = "0.9.0"
-marine-sqlite-connector = "0.8.2"
+marine-sqlite-connector = "0.9.0"

--- a/examples/sqlite/Cargo.toml
+++ b/examples/sqlite/Cargo.toml
@@ -10,5 +10,5 @@ name = "sqlite_test"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk = "0.7.1"
+marine-rs-sdk = "0.9.0"
 marine-sqlite-connector = "0.8.2"

--- a/examples/url-downloader/curl_adapter/Cargo.toml
+++ b/examples/url-downloader/curl_adapter/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/main.rs"
 name = "curl_adapter"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.7.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
 log = "0.4.8"

--- a/examples/url-downloader/curl_adapter/Cargo.toml
+++ b/examples/url-downloader/curl_adapter/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/main.rs"
 name = "curl_adapter"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.10.0", features = ["logger"] }
 log = "0.4.8"

--- a/examples/url-downloader/curl_adapter/Cargo.toml
+++ b/examples/url-downloader/curl_adapter/Cargo.toml
@@ -10,5 +10,5 @@ path = "src/main.rs"
 name = "curl_adapter"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
 log = "0.4.8"

--- a/examples/url-downloader/facade/Cargo.toml
+++ b/examples/url-downloader/facade/Cargo.toml
@@ -10,6 +10,6 @@ name = "facade"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
 anyhow = "1.0.31"
 log = "0.4.8"

--- a/examples/url-downloader/facade/Cargo.toml
+++ b/examples/url-downloader/facade/Cargo.toml
@@ -10,6 +10,6 @@ name = "facade"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.7.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
 anyhow = "1.0.31"
 log = "0.4.8"

--- a/examples/url-downloader/facade/Cargo.toml
+++ b/examples/url-downloader/facade/Cargo.toml
@@ -10,6 +10,6 @@ name = "facade"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.10.0", features = ["logger"] }
 anyhow = "1.0.31"
 log = "0.4.8"

--- a/examples/url-downloader/local_storage/Cargo.toml
+++ b/examples/url-downloader/local_storage/Cargo.toml
@@ -10,7 +10,7 @@ name = "local_storage"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.10.0", features = ["logger"] }
 wasm-tracing-allocator = "0.1.0"
 
 log = "0.4.8"

--- a/examples/url-downloader/local_storage/Cargo.toml
+++ b/examples/url-downloader/local_storage/Cargo.toml
@@ -10,7 +10,7 @@ name = "local_storage"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.7.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
 wasm-tracing-allocator = "0.1.0"
 
 log = "0.4.8"

--- a/examples/url-downloader/local_storage/Cargo.toml
+++ b/examples/url-downloader/local_storage/Cargo.toml
@@ -10,7 +10,7 @@ name = "local_storage"
 path = "src/main.rs"
 
 [dependencies]
-marine-rs-sdk ={ version = "0.9.0", features = ["logger"] }
+marine-rs-sdk ={ version = "0.10.0", features = ["logger"] }
 wasm-tracing-allocator = "0.1.0"
 
 log = "0.4.8"

--- a/marine/Cargo.toml
+++ b/marine/Cargo.toml
@@ -14,8 +14,9 @@ path = "src/lib.rs"
 marine-core = { path = "../core", version = "0.24.0", default-features = false}
 marine-module-interface = { path = "../crates/module-interface", version = "0.7.1" }
 marine-utils = { path = "../crates/utils", version = "0.5.0" }
-marine-rs-sdk-main = { version = "0.9.0", features = ["logger"] }
-marine-rs-sdk = { version = "0.9.0", features = ["logger"] }
+marine-rs-sdk-main = {version = "0.9.0", git = "https://github.com/fluencelabs/marine-rs-sdk", branch = "feat/decouple-call-params", default-features = false, features = ["logger"] }
+marine-rs-sdk = {version = "0.9.0", git = "https://github.com/fluencelabs/marine-rs-sdk", branch = "feat/decouple-call-params", default-features = false, features = ["logger"] }
+
 it-json-serde = { path = "../crates/it-json-serde", version = "0.4.1" }
 marine-wasm-backend-traits = { path = "../crates/wasm-backend-traits", version = "0.3.0"}
 marine-wasmtime-backend = { path = "../crates/wasmtime-backend", version = "0.3.0", optional = true}

--- a/marine/Cargo.toml
+++ b/marine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "marine-runtime"
 description = "The Fluence Wasm Runtime"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Fluence Labs"]
 license = "Apache-2.0"
 edition = "2021"
@@ -11,7 +11,7 @@ name = "marine"
 path = "src/lib.rs"
 
 [dependencies]
-marine-core = { path = "../core", version = "0.23.0", default-features = false}
+marine-core = { path = "../core", version = "0.24.0", default-features = false}
 marine-module-interface = { path = "../crates/module-interface", version = "0.7.1" }
 marine-utils = { path = "../crates/utils", version = "0.5.0" }
 marine-rs-sdk-main = { version = "0.9.0", features = ["logger"] }

--- a/marine/Cargo.toml
+++ b/marine/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/lib.rs"
 marine-core = { path = "../core", version = "0.24.0", default-features = false}
 marine-module-interface = { path = "../crates/module-interface", version = "0.7.1" }
 marine-utils = { path = "../crates/utils", version = "0.5.0" }
-marine-rs-sdk-main = {version = "0.9.0", git = "https://github.com/fluencelabs/marine-rs-sdk", branch = "feat/decouple-call-params", default-features = false, features = ["logger"] }
-marine-rs-sdk = {version = "0.9.0", git = "https://github.com/fluencelabs/marine-rs-sdk", branch = "feat/decouple-call-params", default-features = false, features = ["logger"] }
+marine-rs-sdk-main = {version = "0.10.0", default-features = false, features = ["logger"] }
+marine-rs-sdk = {version = "0.10.0", default-features = false, features = ["logger"] }
 
 it-json-serde = { path = "../crates/it-json-serde", version = "0.4.1" }
 marine-wasm-backend-traits = { path = "../crates/wasm-backend-traits", version = "0.3.0"}

--- a/marine/Cargo.toml
+++ b/marine/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/lib.rs"
 marine-core = { path = "../core", version = "0.23.0", default-features = false}
 marine-module-interface = { path = "../crates/module-interface", version = "0.7.1" }
 marine-utils = { path = "../crates/utils", version = "0.5.0" }
-marine-rs-sdk-main = { version = "0.8.1", features = ["logger"] }
-marine-rs-sdk = { version = "0.8.1", features = ["logger"] }
+marine-rs-sdk-main = { version = "0.9.0", features = ["logger"] }
+marine-rs-sdk = { version = "0.9.0", features = ["logger"] }
 it-json-serde = { path = "../crates/it-json-serde", version = "0.4.1" }
 marine-wasm-backend-traits = { path = "../crates/wasm-backend-traits", version = "0.3.0"}
 marine-wasmtime-backend = { path = "../crates/wasmtime-backend", version = "0.3.0", optional = true}

--- a/marine/tests/wasm_tests/arguments_passing/Cargo.toml
+++ b/marine/tests/wasm_tests/arguments_passing/Cargo.toml
@@ -14,5 +14,5 @@ name = "arguments_passing_effector"
 path = "src/effector.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"
 safe-transmute = "0.11.0"

--- a/marine/tests/wasm_tests/arguments_passing/Cargo.toml
+++ b/marine/tests/wasm_tests/arguments_passing/Cargo.toml
@@ -14,5 +14,5 @@ name = "arguments_passing_effector"
 path = "src/effector.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"
 safe-transmute = "0.11.0"

--- a/marine/tests/wasm_tests/arrays_passing/Cargo.toml
+++ b/marine/tests/wasm_tests/arrays_passing/Cargo.toml
@@ -14,5 +14,5 @@ name = "arrays_passing_effector"
 path = "src/effector.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"
 safe-transmute = "0.11.0"

--- a/marine/tests/wasm_tests/arrays_passing/Cargo.toml
+++ b/marine/tests/wasm_tests/arrays_passing/Cargo.toml
@@ -14,5 +14,5 @@ name = "arrays_passing_effector"
 path = "src/effector.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"
 safe-transmute = "0.11.0"

--- a/marine/tests/wasm_tests/records_passing/Cargo.toml
+++ b/marine/tests/wasm_tests/records_passing/Cargo.toml
@@ -14,5 +14,5 @@ name = "records_passing_pure"
 path = "src/pure.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"
 safe-transmute = "0.11.0"

--- a/marine/tests/wasm_tests/records_passing/Cargo.toml
+++ b/marine/tests/wasm_tests/records_passing/Cargo.toml
@@ -14,5 +14,5 @@ name = "records_passing_pure"
 path = "src/pure.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"
 safe-transmute = "0.11.0"

--- a/marine/tests/wasm_tests/wasi/Cargo.toml
+++ b/marine/tests/wasm_tests/wasi/Cargo.toml
@@ -10,5 +10,5 @@ name = "wasi_effector"
 path = "src/effector.rs"
 
 [dependencies]
-marine-rs-sdk = "0.9.0"
+marine-rs-sdk = "0.10.0"
 safe-transmute = "0.11.0"

--- a/marine/tests/wasm_tests/wasi/Cargo.toml
+++ b/marine/tests/wasm_tests/wasi/Cargo.toml
@@ -10,5 +10,5 @@ name = "wasi_effector"
 path = "src/effector.rs"
 
 [dependencies]
-marine-rs-sdk ="0.7.0"
+marine-rs-sdk = "0.9.0"
 safe-transmute = "0.11.0"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-03-12"
+channel = "nightly-2023-08-27"
 targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-unknown-linux-musl",

--- a/tools/cli/Cargo.toml
+++ b/tools/cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 marine-it-generator = { path = "../../crates/it-generator", version = "0.11.0" }
 marine-it-parser = { path = "../../crates/it-parser", version = "0.13.0" }
-marine-module-info-parser = { path = "../../crates/module-info-parser", version = "0.8.0" }
+marine-module-info-parser = { path = "../../crates/module-info-parser", version = "0.9.0" }
 
 cargo_toml = "0.15.2"
 cargo-lock = "8.0.3"

--- a/tools/repl/Cargo.toml
+++ b/tools/repl/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 fluence-app-service = { path = "../../crates/fluence-app-service", version = "0.28.0", features = ["raw-module-api"] }
-marine-rs-sdk-main = { version = "0.8.1", features = ["logger"] }
+marine-rs-sdk-main = { version = "0.9.0", features = ["logger"] }
 marine-wasm-backend-traits = {path = "../../crates/wasm-backend-traits", version = "0.3.0"}
 
 anyhow = "1.0.71"

--- a/tools/repl/Cargo.toml
+++ b/tools/repl/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 fluence-app-service = { path = "../../crates/fluence-app-service", version = "0.29.0", features = ["raw-module-api"] }
-marine-rs-sdk-main = { version = "0.9.0", features = ["logger"] }
+marine-rs-sdk-main = { version = "0.9.0", git = "https://github.com/fluencelabs/marine-rs-sdk", branch = "feat/decouple-call-params", default-features = false, features = ["logger"] }
 marine-wasm-backend-traits = {path = "../../crates/wasm-backend-traits", version = "0.3.0"}
 
 anyhow = "1.0.71"

--- a/tools/repl/Cargo.toml
+++ b/tools/repl/Cargo.toml
@@ -12,7 +12,7 @@ name = "mrepl"
 path = "src/main.rs"
 
 [dependencies]
-fluence-app-service = { path = "../../crates/fluence-app-service", version = "0.28.0", features = ["raw-module-api"] }
+fluence-app-service = { path = "../../crates/fluence-app-service", version = "0.29.0", features = ["raw-module-api"] }
 marine-rs-sdk-main = { version = "0.9.0", features = ["logger"] }
 marine-wasm-backend-traits = {path = "../../crates/wasm-backend-traits", version = "0.3.0"}
 

--- a/tools/repl/Cargo.toml
+++ b/tools/repl/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 fluence-app-service = { path = "../../crates/fluence-app-service", version = "0.29.0", features = ["raw-module-api"] }
-marine-rs-sdk-main = { version = "0.9.0", git = "https://github.com/fluencelabs/marine-rs-sdk", branch = "feat/decouple-call-params", default-features = false, features = ["logger"] }
+marine-rs-sdk-main = { version = "0.10.0", default-features = false, features = ["logger"] }
 marine-wasm-backend-traits = {path = "../../crates/wasm-backend-traits", version = "0.3.0"}
 
 anyhow = "1.0.71"


### PR DESCRIPTION
Marine-rs-sdk contains #[no_mangle] exported functions, so updating its minor version is a breaking change