### PR TITLE
feat!: rework wasi mapped dirs handing, relax restrictions

### DIFF
--- a/crates/fluence-app-service/src/config.rs
+++ b/crates/fluence-app-service/src/config.rs
@@ -25,5 +25,8 @@ pub struct AppServiceConfig {
     pub service_working_dir: PathBuf,
     /// Location for /tmp and /local dirs.
     pub service_base_dir: PathBuf,
+    /// If true, all host paths in `wasi.mapped_dirs` treated as relative to `self.service_working_dir`,
+    /// if false, all host paths in `wasi.mapped_dirs` are used as-is.
+    pub preprocess_wasi_paths: bool,
     pub marine_config: MarineConfig,
 }

--- a/crates/fluence-app-service/src/config.rs
+++ b/crates/fluence-app-service/src/config.rs
@@ -25,8 +25,5 @@ pub struct AppServiceConfig {
     pub service_working_dir: PathBuf,
     /// Location for /tmp and /local dirs.
     pub service_base_dir: PathBuf,
-    /// If true, all host paths in `wasi.mapped_dirs` treated as relative to `self.service_working_dir`,
-    /// if false, all host paths in `wasi.mapped_dirs` are used as-is.
-    pub preprocess_wasi_paths: bool,
     pub marine_config: MarineConfig,
 }

--- a/crates/fluence-app-service/src/raw_toml_config.rs
+++ b/crates/fluence-app-service/src/raw_toml_config.rs
@@ -30,6 +30,7 @@ use std::path::PathBuf;
 pub struct TomlAppServiceConfig {
     pub service_working_dir: Option<String>,
     pub service_base_dir: Option<String>,
+    pub preprocess_wasi_paths: Option<bool>,
 
     #[serde(flatten)]
     pub toml_marine_config: TomlMarineConfig,
@@ -65,6 +66,7 @@ impl TryInto<AppServiceConfig> for TomlAppServiceConfig {
         Ok(AppServiceConfig {
             service_working_dir,
             service_base_dir: service_tmp_dir,
+            preprocess_wasi_paths: self.preprocess_wasi_paths.unwrap_or(true),
             marine_config,
         })
     }

--- a/crates/fluence-app-service/src/raw_toml_config.rs
+++ b/crates/fluence-app-service/src/raw_toml_config.rs
@@ -53,8 +53,8 @@ impl TryInto<AppServiceConfig> for TomlAppServiceConfig {
         let marine_config = self.toml_marine_config.try_into()?;
         let service_working_dir = match self.service_working_dir {
             Some(service_base_dir) => PathBuf::from(service_base_dir),
-            // use tmp dir for service base dir if it isn't defined
-            None => std::env::temp_dir(),
+            // use current dir for service base dir if it isn't defined
+            None => std::env::current_dir(),
         };
 
         let service_tmp_dir = match self.service_base_dir {

--- a/crates/fluence-app-service/src/raw_toml_config.rs
+++ b/crates/fluence-app-service/src/raw_toml_config.rs
@@ -54,7 +54,7 @@ impl TryInto<AppServiceConfig> for TomlAppServiceConfig {
         let service_working_dir = match self.service_working_dir {
             Some(service_base_dir) => PathBuf::from(service_base_dir),
             // use current dir for service base dir if it isn't defined
-            None => std::env::current_dir(),
+            None => std::env::current_dir()?,
         };
 
         let service_tmp_dir = match self.service_base_dir {

--- a/crates/fluence-app-service/src/raw_toml_config.rs
+++ b/crates/fluence-app-service/src/raw_toml_config.rs
@@ -30,7 +30,6 @@ use std::path::PathBuf;
 pub struct TomlAppServiceConfig {
     pub service_working_dir: Option<String>,
     pub service_base_dir: Option<String>,
-    pub preprocess_wasi_paths: Option<bool>,
 
     #[serde(flatten)]
     pub toml_marine_config: TomlMarineConfig,
@@ -66,7 +65,6 @@ impl TryInto<AppServiceConfig> for TomlAppServiceConfig {
         Ok(AppServiceConfig {
             service_working_dir,
             service_base_dir: service_tmp_dir,
-            preprocess_wasi_paths: self.preprocess_wasi_paths.unwrap_or(true),
             marine_config,
         })
     }

--- a/crates/fluence-app-service/src/service.rs
+++ b/crates/fluence-app-service/src/service.rs
@@ -160,13 +160,13 @@ impl AppService {
 
         for module in &mut config.marine_config.modules_config {
             module.config.extend_wasi_envs(envs.clone());
-            // Moves app preopened files and mapped dirs to the &working dir, keeping old aliases.
-            module.config.root_wasi_files_at(working_dir);
+            if config.preprocess_wasi_paths {
+                // Moves app preopened files and mapped dirs to the &working dir, keeping old aliases.
+                module.config.root_wasi_files_at(working_dir);
+            }
             // Adds /tmp and /local to wasi.
             // It is important to do it after rooting preopens at working dir, because /tmp and /local are in a separate temporary dir
-            module
-                .config
-                .extend_wasi_files(<_>::default(), mapped_dirs.clone());
+            module.config.extend_wasi_files(mapped_dirs.clone());
 
             // Create all mapped directories if they do not exist
             // Needed to provide ability to run the same services both in mrepl and rust-peer

--- a/crates/fluence-app-service/src/service.rs
+++ b/crates/fluence-app-service/src/service.rs
@@ -160,10 +160,9 @@ impl AppService {
 
         for module in &mut config.marine_config.modules_config {
             module.config.extend_wasi_envs(envs.clone());
-            if config.preprocess_wasi_paths {
-                // Moves app preopened files and mapped dirs to the &working dir, keeping old aliases.
-                module.config.root_wasi_files_at(working_dir);
-            }
+            // Moves relative paths in mapped dirs to the &working dir, keeping old aliases.
+            module.config.root_wasi_files_at(working_dir);
+
             // Adds /tmp and /local to wasi.
             // It is important to do it after rooting preopens at working dir, because /tmp and /local are in a separate temporary dir
             module.config.extend_wasi_files(mapped_dirs.clone());


### PR DESCRIPTION
* service_working_dir is now std::env::current_dir by default
* absolute paths and paths containing ".." are now allowed
* preopened files are now ignored