### PR TITLE
feat(cli): improve error reporting when cannot run cargo

### DIFF
--- a/tools/cli/src/utils.rs
+++ b/tools/cli/src/utils.rs
@@ -35,7 +35,7 @@ fn run_command<T: Into<Stdio>>(
 ) -> Result<String, anyhow::Error> {
     let process = command.stdout(stdout_config).spawn().map_err(|e| {
         anyhow::anyhow!(
-            r#"Cannot run "{}": {}"#,
+            r#"cannot run "{}": {}"#,
             command.get_program().to_string_lossy(),
             e
         )


### PR DESCRIPTION
Previously program that has not been found or the command arguments were not printed by marine cli. Now they are added:

```
$ marine build -p wasm-greeting
Error: cannot run `cargo`: executable not found in $PATH
```

```
$ marine build -p wasm-greeting
Error: cannot run `cargo`: Permission denied (os error 13)
```

```
$ marine build -p wasm-greeting
error: no such command: `buildd`

	Did you mean `build`?

	View all installed commands with `cargo --list`
	Find a package to install `buildd` with `cargo search cargo-buildd`
Error: command `cargo buildd --target wasm32-wasi --message-format json-render-diagnostics -p wasm-greeting` exited with exit status: 101
```
