### PR TITLE
fix: replace wasi with wasip1

### DIFF
--- a/examples/call_parameters/build.sh
+++ b/examples/call_parameters/build.sh
@@ -5,4 +5,4 @@ cargo run  --release -p marine -- build --release;
 rm -f artifacts/* || true;
 mkdir -p artifacts;
 
-cp ../../target/wasm32-wasi/release/call_parameters.wasm artifacts/;
+cp ../../target/wasm32-wasip1/release/call_parameters.wasm artifacts/;

--- a/examples/failing/build.sh
+++ b/examples/failing/build.sh
@@ -6,4 +6,4 @@ cargo run  --release -p marine -- build --release
 rm artifacts/* || true
 mkdir -p artifacts
 
-cp ../../target/wasm32-wasi/release/failing.wasm artifacts/
+cp ../../target/wasm32-wasip1/release/failing.wasm artifacts/

--- a/examples/greeting/build.sh
+++ b/examples/greeting/build.sh
@@ -6,4 +6,4 @@ cargo run  --release -p marine -- build --release
 rm artifacts/* || true
 mkdir -p artifacts
 
-cp ../../target/wasm32-wasi/release/greeting.wasm artifacts/
+cp ../../target/wasm32-wasip1/release/greeting.wasm artifacts/

--- a/examples/greeting_record/build.sh
+++ b/examples/greeting_record/build.sh
@@ -6,4 +6,4 @@ cargo run  --release -p marine -- build --release
 rm artifacts/* || true
 mkdir -p artifacts
 
-cp ../../target/wasm32-wasi/release/greeting-record.wasm artifacts/
+cp ../../target/wasm32-wasip1/release/greeting-record.wasm artifacts/

--- a/examples/ipfs-node/build.sh
+++ b/examples/ipfs-node/build.sh
@@ -14,5 +14,5 @@
 rm artifacts/* || true
 mkdir -p artifacts
 
-cp ../../target/wasm32-wasi/release/ipfs_effector.wasm artifacts/
-cp ../../target/wasm32-wasi/release/ipfs_pure.wasm artifacts/
+cp ../../target/wasm32-wasip1/release/ipfs_effector.wasm artifacts/
+cp ../../target/wasm32-wasip1/release/ipfs_pure.wasm artifacts/

--- a/examples/motivational-example/build.sh
+++ b/examples/motivational-example/build.sh
@@ -14,5 +14,5 @@
 rm -f artifacts/* || true
 mkdir -p artifacts
 
-cp ../../target/wasm32-wasi/release/shrek.wasm artifacts/
-cp ../../target/wasm32-wasi/release/donkey.wasm artifacts/
+cp ../../target/wasm32-wasip1/release/shrek.wasm artifacts/
+cp ../../target/wasm32-wasip1/release/donkey.wasm artifacts/

--- a/examples/records/build.sh
+++ b/examples/records/build.sh
@@ -14,5 +14,6 @@
 rm artifacts/* || true
 mkdir -p artifacts
 
-cp ../../target/wasm32-wasi/release/records_effector.wasm artifacts/
-cp ../../target/wasm32-wasi/release/records_pure.wasm artifacts/
+export MARINE_PROJECT=wasm32-wasip1
+cp ../../target/$MARINE_TARGET/release/records_effector.wasm artifacts/
+cp ../../target/$MARINE_TARGET/release/records_pure.wasm artifacts/

--- a/examples/sqlite/build.sh
+++ b/examples/sqlite/build.sh
@@ -6,6 +6,6 @@ cargo run  --release -p marine -- build --release
 rm artifacts/* || true
 mkdir -p artifacts
 
-cp ../../target/wasm32-wasi/release/sqlite_test.wasm artifacts/
+cp ../../target/wasm32-wasip1/release/sqlite_test.wasm artifacts/
 wget https://github.com/fluencelabs/sqlite/releases/download/v0.14.0_w/sqlite3.wasm
 mv sqlite3.wasm artifacts/

--- a/examples/url-downloader/build.sh
+++ b/examples/url-downloader/build.sh
@@ -19,6 +19,7 @@
 rm -f artifacts/* || true
 mkdir -p artifacts
 
-cp ../../target/wasm32-wasi/release/local_storage.wasm artifacts/
-cp ../../target/wasm32-wasi/release/curl_adapter.wasm artifacts/
-cp ../../target/wasm32-wasi/release/facade.wasm artifacts/
+export MARINE_TARGET=wasm32-wasip1
+cp ../../target/$MARINE_TARGET/release/local_storage.wasm artifacts/
+cp ../../target/$MARINE_TARGET/release/curl_adapter.wasm artifacts/
+cp ../../target/$MARINE_TARGET/release/facade.wasm artifacts/

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,9 +1,9 @@
 [toolchain]
-channel = "nightly-2023-11-11"
+channel = "nightly-2024-06-10"
 targets = [
   "x86_64-unknown-linux-gnu",
   "x86_64-unknown-linux-musl",
   "x86_64-apple-darwin",
-  "wasm32-wasi",
+  "wasm32-wasip1",
   "wasm32-unknown-unknown",
 ]

--- a/tools/cli/src/build.rs
+++ b/tools/cli/src/build.rs
@@ -42,7 +42,7 @@ pub(crate) fn build(trailing_args: Vec<&str>) -> CLIResult<()> {
     env_logger::init();
 
     let mut cargo = Command::new("cargo");
-    cargo.arg("build").arg("--target").arg("wasm32-wasi");
+    cargo.arg("build").arg("--target").arg("wasm32-wasip1");
     cargo.arg("--message-format").arg("json-render-diagnostics");
     cargo.args(trailing_args.iter());
 


### PR DESCRIPTION
refer to the renaming:
https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip1.html
currently in beta and nightly, the wasm32-wasi target has been removed.